### PR TITLE
Force Doxygen to document *Callbacks enums.

### DIFF
--- a/include/TGUI/AnimatedPicture.hpp
+++ b/include/TGUI/AnimatedPicture.hpp
@@ -276,11 +276,13 @@ namespace tgui
       public:
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        // Defines specific triggers to AnimatedPicture.
+        /// Defines specific triggers to AnimatedPicture.
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         enum AnimatedPictureCallbacks
         {
+            /// Animation ended
             AnimationFinished = ClickableWidgetCallbacksCount * 1,
+            /// Means all Callbacks defined in AnimatedPicture and its parent Widgets
             AllAnimatedPictureCallbacks = ClickableWidgetCallbacksCount * 2 - 1,
             AnimatedPictureCallbacksCount = ClickableWidgetCallbacksCount * 2
         };

--- a/include/TGUI/Button.hpp
+++ b/include/TGUI/Button.hpp
@@ -240,12 +240,15 @@ namespace tgui
       public:
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        // Defines specific triggers to Button.
+        /// Defines specific triggers to Button.
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         enum ButtonCallbacks
         {
+            /// Space key was pressed
             SpaceKeyPressed      = ClickableWidgetCallbacksCount * 1,
+            /// Return key was pressed
             ReturnKeyPressed     = ClickableWidgetCallbacksCount * 2,
+            /// Means all Callbacks defined in Button and its parent Widgets
             AllButtonCallbacks   = ClickableWidgetCallbacksCount * 4 - 1,
             ButtonCallbacksCount = ClickableWidgetCallbacksCount * 4
         };

--- a/include/TGUI/ChatBox.hpp
+++ b/include/TGUI/ChatBox.hpp
@@ -292,10 +292,11 @@ namespace tgui
       public:
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        // Defines specific triggers to ChatBox.
+        /// Defines specific triggers to ChatBox.
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         enum ChatBoxCallbacks
         {
+            /// Means all Callbacks defined in ChatBox and its parent Widgets
             AllChatBoxCallbacks = WidgetCallbacksCount - 1,
             ChatBoxCallbacksCount = WidgetCallbacksCount
         };

--- a/include/TGUI/Checkbox.hpp
+++ b/include/TGUI/Checkbox.hpp
@@ -274,14 +274,19 @@ namespace tgui
       public:
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        // Defines specific triggers to Checkbox.
+        /// Defines specific triggers to Checkbox.
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         enum CheckboxCallbacks
         {
+            /// Checkbox was checked
             Checked = ClickableWidgetCallbacksCount * 1,
+            /// Checkbox was unchecked
             Unchecked = ClickableWidgetCallbacksCount * 2,
+            /// Space key was pressed
             SpaceKeyPressed = ClickableWidgetCallbacksCount * 8,
+            /// Return key was pressed
             ReturnKeyPressed = ClickableWidgetCallbacksCount * 16,
+            /// Means all Callbacks defined in Checkbox and its parent Widgets
             AllCheckboxCallbacks = ClickableWidgetCallbacksCount * 32 - 1,
             CheckboxCallbacksCount = ClickableWidgetCallbacksCount * 32
         };

--- a/include/TGUI/ChildWindow.hpp
+++ b/include/TGUI/ChildWindow.hpp
@@ -428,13 +428,16 @@ namespace tgui
       public:
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        // Defines specific triggers to ChildWindow.
+        /// Defines specific triggers to ChildWindow.
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         enum ChildWindowCallbacks
         {
+            /// Child window was closed
             Closed = WidgetCallbacksCount * 1,
+            /// Child window was moved
             Moved = WidgetCallbacksCount * 2,
 //            Resized = WidgetCallbacksCount * 4,
+            /// Means all Callbacks defined in ChildWindow and its parent Widgets
             AllChildWindowCallbacks = WidgetCallbacksCount * 8 - 1,
             ChildWindowCallbacksCount = WidgetCallbacksCount * 8
         };

--- a/include/TGUI/ClickableWidget.hpp
+++ b/include/TGUI/ClickableWidget.hpp
@@ -120,13 +120,17 @@ namespace tgui
       public:
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        // Defines specific triggers to ClickableWidget.
+        /// Defines specific triggers to ClickableWidget.
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         enum ClickableWidgetCallbacks
         {
+            /// The left mouse button was pressed
             LeftMousePressed              = WidgetCallbacksCount * 1,
+            /// The left mouse button was released
             LeftMouseReleased             = WidgetCallbacksCount * 2,
+            /// The left mouse button was clicked
             LeftMouseClicked              = WidgetCallbacksCount * 4,
+            /// Means all Callbacks defined in ClickableWidget and its parent Widgets
             AllClickableWidgetCallbacks   = WidgetCallbacksCount * 8 - 1,
             ClickableWidgetCallbacksCount = WidgetCallbacksCount * 8
         };

--- a/include/TGUI/ComboBox.hpp
+++ b/include/TGUI/ComboBox.hpp
@@ -532,11 +532,13 @@ namespace tgui
       public:
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        // Defines specific triggers to ComboBox.
+        /// Defines specific triggers to ComboBox.
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         enum ComboBoxCallbacks
         {
+            /// A new item was selected
             ItemSelected = WidgetCallbacksCount * 1,
+            /// Means all Callbacks defined in ComboBox and its parent Widgets
             AllComboBoxCallbacks = WidgetCallbacksCount * 2 - 1,
             ComboBoxCallbacksCount = WidgetCallbacksCount * 2
         };

--- a/include/TGUI/EditBox.hpp
+++ b/include/TGUI/EditBox.hpp
@@ -486,12 +486,15 @@ namespace tgui
       public:
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        // Defines specific triggers to EditBox.
+        /// Defines specific triggers to EditBox.
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         enum EditBoxCallbacks
         {
+            /// Text changed
             TextChanged = ClickableWidgetCallbacksCount * 1,
+            /// Return key was pressed
             ReturnKeyPressed = ClickableWidgetCallbacksCount * 2,
+            /// Means all Callbacks defined in EditBox and its parent Widgets
             AllEditBoxCallbacks = ClickableWidgetCallbacksCount * 4 - 1,
             EditBoxCallbacksCount = ClickableWidgetCallbacksCount * 4
         };

--- a/include/TGUI/Grid.hpp
+++ b/include/TGUI/Grid.hpp
@@ -247,11 +247,11 @@ namespace tgui
       public:
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        // Defines specific triggers to Grid.
+        /// Defines specific triggers to Grid.
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         enum GridCallbacks
         {
-            AllGridCallbacks = WidgetCallbacksCount - 1,
+            AllGridCallbacks = WidgetCallbacksCount - 1, ///< Means all Callbacks defined in Grid and its parent Widgets
             GridCallbacksCount = WidgetCallbacksCount
         };
 

--- a/include/TGUI/Label.hpp
+++ b/include/TGUI/Label.hpp
@@ -272,10 +272,11 @@ namespace tgui
       public:
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        // Defines specific triggers to Label.
+        /// Defines specific triggers to Label.
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         enum LabelCallbacks
         {
+            /// Means all Callbacks defined in Label and its parent Widgets
             AllLabelCallbacks   = ClickableWidgetCallbacksCount - 1,
             LabelCallbacksCount = ClickableWidgetCallbacksCount
         };

--- a/include/TGUI/ListBox.hpp
+++ b/include/TGUI/ListBox.hpp
@@ -530,11 +530,13 @@ namespace tgui
       public:
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        // Defines specific triggers to ListBox.
+        /// Defines specific triggers to ListBox.
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         enum ListBoxCallbacks
         {
+            /// A new item was selected
             ItemSelected = WidgetCallbacksCount * 1,
+            /// Means all Callbacks defined in ListBox and its parent Widgets
             AllListBoxCallbacks = WidgetCallbacksCount * 2 - 1,
             ListBoxCallbacksCount = WidgetCallbacksCount * 2
         };

--- a/include/TGUI/LoadingBar.hpp
+++ b/include/TGUI/LoadingBar.hpp
@@ -296,12 +296,15 @@ namespace tgui
       public:
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        // Defines specific triggers to LoadingBar.
+        /// Defines specific triggers to LoadingBar.
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         enum LoadingBarCallbacks
         {
+            /// Value changed
             ValueChanged = ClickableWidgetCallbacksCount * 1,
+            /// Value reached the max value.
             LoadingBarFull = ClickableWidgetCallbacksCount * 2,
+            /// Means all Callbacks defined in LoadingBar and its parent Widgets
             AllLoadingBarCallbacks = ClickableWidgetCallbacksCount * 4 - 1,
             LoadingBarCallbacksCount = ClickableWidgetCallbacksCount * 4
         };

--- a/include/TGUI/MenuBar.hpp
+++ b/include/TGUI/MenuBar.hpp
@@ -357,12 +357,12 @@ namespace tgui
       public:
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        // Defines specific triggers to MenuBar.
+        /// Defines specific triggers to MenuBar.
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         enum MenuBarCallbacks
         {
-            MenuItemClicked = WidgetCallbacksCount * 1,
-            AllMenuBarCallbacks = WidgetCallbacksCount * 2 - 1,
+            MenuItemClicked = WidgetCallbacksCount * 1, ///< A menu item was clicked
+            AllMenuBarCallbacks = WidgetCallbacksCount * 2 - 1, ///< Means all Callbacks defined in MenuBar and its parent Widgets
             MenuBarCallbacksCount = WidgetCallbacksCount * 2
         };
 

--- a/include/TGUI/MessageBox.hpp
+++ b/include/TGUI/MessageBox.hpp
@@ -212,11 +212,13 @@ namespace tgui
       public:
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        // Defines specific triggers to MessageBox.
+        /// Defines specific triggers to MessageBox.
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         enum MessageBoxCallbacks
         {
+            /// Button clicked
             ButtonClicked            = ChildWindowCallbacksCount * 1,
+            /// Means all Callbacks defined in MessageBox and its parent Widgets
             AllMessageBoxCallbacks   = ChildWindowCallbacksCount * 2 - 1,
             MessageBoxCallbacksCount = ChildWindowCallbacksCount * 2
         };

--- a/include/TGUI/Panel.hpp
+++ b/include/TGUI/Panel.hpp
@@ -189,14 +189,14 @@ namespace tgui
       public:
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        // Defines specific triggers to Panel.
+        /// Defines specific triggers to Panel.
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         enum PanelCallbacks
         {
-            LeftMousePressed = WidgetCallbacksCount * 1,
-            LeftMouseReleased = WidgetCallbacksCount * 2,
-            LeftMouseClicked = WidgetCallbacksCount * 4,
-            AllPanelCallbacks = WidgetCallbacksCount * 8 - 1,
+            LeftMousePressed = WidgetCallbacksCount * 1, ///< The left mouse button was pressed
+            LeftMouseReleased = WidgetCallbacksCount * 2, ///< The left mouse button was released
+            LeftMouseClicked = WidgetCallbacksCount * 4, ///< The left mouse button was clicked
+            AllPanelCallbacks = WidgetCallbacksCount * 8 - 1, ///< Means all Callbacks defined in Panel and its parent Widgets
             PanelCallbacksCount = WidgetCallbacksCount * 8
         };
 

--- a/include/TGUI/Picture.hpp
+++ b/include/TGUI/Picture.hpp
@@ -186,10 +186,11 @@ namespace tgui
       public:
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        // Defines specific triggers to Picture.
+        /// Defines specific triggers to Picture.
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         enum PictureCallbacks
         {
+            /// Means all Callbacks defined in Picture and its parent Widgets
             AllPictureCallbacks   = ClickableWidgetCallbacksCount - 1,
             PictureCallbacksCount = ClickableWidgetCallbacksCount
         };

--- a/include/TGUI/RadioButton.hpp
+++ b/include/TGUI/RadioButton.hpp
@@ -118,10 +118,11 @@ namespace tgui
       public:
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        // Defines specific triggers to RadioButton.
+        /// Defines specific triggers to RadioButton.
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         enum RadioButtonCallbacks
         {
+            /// Means all Callbacks defined in RadioButton and its parent Widgets
             AllRadioButtonCallbacks = CheckboxCallbacksCount - 1,
             RadioButtonCallbacksCount = CheckboxCallbacksCount
         };

--- a/include/TGUI/Scrollbar.hpp
+++ b/include/TGUI/Scrollbar.hpp
@@ -189,11 +189,11 @@ namespace tgui
       public:
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        // Defines specific triggers to Scrollbar.
+        /// Defines specific triggers to Scrollbar.
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         enum ScrollbarCallbacks
         {
-            AllScrollbarCallbacks = SliderCallbacksCount - 1,
+            AllScrollbarCallbacks = SliderCallbacksCount - 1, ///< Means all Callbacks defined in Scrollbar and its parent Widgets
             ScrollbarCallbacksCount = SliderCallbacksCount
         };
 

--- a/include/TGUI/Slider.hpp
+++ b/include/TGUI/Slider.hpp
@@ -244,12 +244,12 @@ namespace tgui
       public:
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        // Defines specific triggers to Slider.
+        /// Defines specific triggers to Slider.
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         enum SliderCallbacks
         {
-            ValueChanged = WidgetCallbacksCount * 1,
-            AllSliderCallbacks = WidgetCallbacksCount * 2 - 1,
+            ValueChanged = WidgetCallbacksCount * 1, ///< Value changed (Slider moved)
+            AllSliderCallbacks = WidgetCallbacksCount * 2 - 1, ///< Means all Callbacks defined in Slider and its parent Widgets
             SliderCallbacksCount = WidgetCallbacksCount * 2
         };
 

--- a/include/TGUI/Slider2d.hpp
+++ b/include/TGUI/Slider2d.hpp
@@ -256,12 +256,15 @@ namespace tgui
       public:
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        // Defines specific triggers to Slider2d.
+        /// Defines specific triggers to Slider2d.
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         enum Slider2dCallbacks
         {
+            /// Value changed (slider moved)
             ValueChanged = ClickableWidgetCallbacksCount * 1,
-            ThumbReturnedToCenter = ClickableWidgetCallbacksCount * 2,
+            /// Thumb returned to center
+            ThumbReturnedToCenter = ClickableWidgetCallbacksCount * 2, 
+            /// Means all Callbacks defined in Slider2d and its parent Widgets
             AllSlider2dCallbacks = ClickableWidgetCallbacksCount * 4 - 1,
             Slider2dCallbacksCount = ClickableWidgetCallbacksCount * 4
         };

--- a/include/TGUI/SpinButton.hpp
+++ b/include/TGUI/SpinButton.hpp
@@ -230,11 +230,13 @@ namespace tgui
       public:
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        // Defines specific triggers to SpinButton.
+        /// Defines specific triggers to SpinButton.
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         enum SpinButtonCallbacks
         {
+            /// Value has changed
             ValueChanged = ClickableWidgetCallbacksCount * 1,
+            /// Means all Callbacks defined in TextBox and its parent Widgets
             AllSpinButtonCallbacks = ClickableWidgetCallbacksCount * 2 - 1,
             SpinButtonCallbacksCount = ClickableWidgetCallbacksCount * 2
         };

--- a/include/TGUI/SpriteSheet.hpp
+++ b/include/TGUI/SpriteSheet.hpp
@@ -162,11 +162,11 @@ namespace tgui
       public:
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        // Defines specific triggers to SpriteSheet.
+        /// Defines specific triggers to SpriteSheet.
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         enum SpriteSheetCallbacks
         {
-            AllSpriteSheetCallbacks = PictureCallbacksCount - 1,
+            AllSpriteSheetCallbacks = PictureCallbacksCount - 1, ///< Means all Callbacks defined in SpriteSheet and its parent Widgets
             SpriteSheetCallbacksCount = PictureCallbacksCount
         };
 

--- a/include/TGUI/Tab.hpp
+++ b/include/TGUI/Tab.hpp
@@ -389,12 +389,12 @@ namespace tgui
       public:
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        // Defines specific triggers to Tab.
+        /// Defines specific triggers to Tab.
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         enum TabCallbacks
         {
-            TabChanged = WidgetCallbacksCount * 1,
-            AllTabCallbacks = WidgetCallbacksCount * 2 - 1,
+            TabChanged = WidgetCallbacksCount * 1, ///< Current Tab changed
+            AllTabCallbacks = WidgetCallbacksCount * 2 - 1, ///< Means all Callbacks defined in Tab and its parent Widgets
             TabCallbacksCount = WidgetCallbacksCount * 2
         };
 

--- a/include/TGUI/TextBox.hpp
+++ b/include/TGUI/TextBox.hpp
@@ -500,12 +500,12 @@ namespace tgui
       public:
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        // Defines specific triggers to TextBox.
+        /// Defines specific triggers to TextBox.
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         enum TextBoxCallbacks
         {
-            TextChanged = WidgetCallbacksCount * 1,
-            AllTextBoxCallbacks = WidgetCallbacksCount * 2 - 1,
+            TextChanged = WidgetCallbacksCount * 1, ///< Text has changed
+            AllTextBoxCallbacks = WidgetCallbacksCount * 2 - 1, ///< Means all Callbacks defined in TextBox and its parent Widgets
             TextBoxCallbacksCount = WidgetCallbacksCount * 2
         };
 

--- a/include/TGUI/Widgets.hpp
+++ b/include/TGUI/Widgets.hpp
@@ -354,15 +354,15 @@ namespace tgui
       public:
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        // Defines specific triggers to Widget.
+        /// Defines specific triggers to Widget.
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         enum WidgetCallbacks
         {
-            None = 0,
-            Focused = 1,
-            Unfocused = 2,
-            MouseEntered = 4,
-            MouseLeft = 8,
+            None = 0, ///< No trigger
+            Focused = 1, ///< Widget gained focus.
+            Unfocused = 2, ///< Widget lost focus.
+            MouseEntered = 4, ///< Mouse cursor entered in the Widget area.
+            MouseLeft = 8, ///< Mouse cursor left the Widget area.
             WidgetCallbacksCount = 16
         };
 


### PR DESCRIPTION
Currently, there is nowhere in tgui documentation the list of all Callbacks available for each Widget.
This change will force doxygen to generate the list of all Callbacks available for each Widget.
