### PR TITLE
Create .gitignore and ignore Config.hpp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+include/TGUI/Config.hpp


### PR DESCRIPTION
Every time CMake is run Config.hpp shows up in the uncommitted changes.
https://github.com/texus/TGUI/blob/31f3ce84766850b4c4493e7c9c3d4e2a46d3534e/CMakeLists.txt#L29-L30
Even though it is just a minor annoyance, why not avoid it?
