### PR TITLE
OS X 10.10 update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ endif()
 # Set the correct architecture on mac
 if ( SFML_OS_MACOSX )
     if( NOT CMAKE_OSX_ARCHITECTURES )
-        set( CMAKE_OSX_ARCHITECTURES "i386;x86_64" CACHE STRING "Build architectures for OSX" FORCE )
+        set( CMAKE_OSX_ARCHITECTURES "x86_64" CACHE STRING "Build architectures for OSX" FORCE )
     endif()
 endif()
 

--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -22,7 +22,7 @@ elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
     # detect OS X version. (use '/usr/bin/sw_vers -productVersion' to extract V from '10.V.x'.)
     EXEC_PROGRAM(/usr/bin/sw_vers ARGS -productVersion OUTPUT_VARIABLE MACOSX_VERSION_RAW)
-    STRING(REGEX REPLACE "10\\.([0-9]).*" "\\1" MACOSX_VERSION "${MACOSX_VERSION_RAW}")
+    STRING(REGEX REPLACE "10\\.([0-9])|(10).*" "\\1" MACOSX_VERSION "${MACOSX_VERSION_RAW}")
     if(${MACOSX_VERSION} LESS 5)
         message(FATAL_ERROR "Unsupported version of OS X : ${MACOSX_VERSION_RAW}")
         return()


### PR DESCRIPTION
This is more like a question than a PR because I'm removing the i386 arch. I'd really like to know **why you keep 32 bits compatibility**. Since I compiled SFML for x86_64 arch i couldn't link TGUI without removing the i386.

Other than that I tested the FullExample and it works as expected on OS X 10.10
