### PR TITLE
Fix typo and format of BoxLayout documentation

### DIFF
--- a/include/TGUI/BoxLayout.hpp
+++ b/include/TGUI/BoxLayout.hpp
@@ -52,7 +52,7 @@ namespace tgui
 
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        /// @brief Changes the size of the layout.
+        /// @brief Changes the size of the layout
         ///
         /// @param size  The new size of the layout
         ///
@@ -62,9 +62,9 @@ namespace tgui
 
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        /// @brief Changes the font the child widgets.
+        /// @brief Changes the font the child widgets
         ///
-        /// @param font  The new font.
+        /// @param font  The new font
         ///
         /// When you don't call this function then the font from the parent widget will be used.
         ///
@@ -73,36 +73,36 @@ namespace tgui
 
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        /// @brief Insert a widget to the layout.
+        /// @brief Inserts a widget to the layout
         ///
         /// @param widget      Pointer to the widget you would like to add
         /// @param index       Index of the widget in the container
         /// @param widgetName  An identifier to access to the widget later
         ///
-        /// The widget will have ratio 1.
+        /// The widget will have a ratio of 1.
         ///
         /// If the index is too high, the widget will simply be added at the end of the list.
         ///
-        /// @return False when the index was too high
+        /// @return False if the index was too high
         ///
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         bool insert(std::size_t index, const tgui::Widget::Ptr& widget, const sf::String& widgetName = "");
 
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        /// @brief Adds a widget at the end of the layout.
+        /// @brief Adds a widget at the end of the layout
         ///
         /// @param widget      Pointer to the widget you would like to add
         /// @param widgetName  An identifier to access to the widget later
         ///
-        /// The widget will have ratio 1.
+        /// The widget will have a ratio of 1.
         ///
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         void add(const tgui::Widget::Ptr& widget, const sf::String& widgetName = "") override;
 
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        /// @brief Adds a space at the end of the layout and immediately set its ratio.
+        /// @brief Adds a space at the end of the layout and immediately set its ratio
         ///
         /// @param ratio  Ratio for the space
         ///
@@ -111,88 +111,91 @@ namespace tgui
 
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        /// @brief Insert a space to the layout and immediately set its ratio.
+        /// @brief Inserts a space to the layout and immediately set its ratio
         ///
         /// @param index  Index of the space in the container
         /// @param ratio  Ratio for the space
         ///
         /// If the index is too high, the space will simply be added at the end of the list.
         ///
-        /// @return False when the index was too high
+        /// @return False if the index was too high
         ///
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         bool insertSpace(std::size_t index, float ratio = 1);
 
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        /// @brief Removes a single widget that was added to the container.
+        /// @brief Removes a single widget that was added to the container
         ///
         /// @param widget  Pointer to the widget to remove
         ///
-        /// @return True when widget is removed, false when widget was not found
+        /// @return True if widget is removed, false if widget was not found
         ///
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         bool remove(const tgui::Widget::Ptr& widget) override;
 
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        /// @brief Removes a single widget that was added to the container.
+        /// @brief Removes a single widget that was added to the container
         ///
         /// @param index  Index in the layout of the widget to remove
         ///
-        /// @return False when the index was too high
+        /// @return False if the index was too high
         ///
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         bool remove(std::size_t index);
 
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        /// @brief Returns the widget at the given index in the layout.
+        /// @brief Returns the widget at the given index in the layout
         ///
         /// @param index  Index of the widget in the layout
         ///
-        /// @return Widget of given index, or nullptr when index was too high
+        /// @return Widget of given index, or nullptr if index was too high
         ///
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         Widget::Ptr get(std::size_t index);
 
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        /// @brief Change the ratio of a widget.
+        /// @brief Changes the ratio of a widget
         ///
         /// The ratio is the size that will have a widget relatively to others. By default, the ratio is equal to 1.
-        /// So setting a ratio to 2 means that the widget will be 2 times larger than others.
+        ///
+        /// So setting a ratio to 2 means that the widget will be 2 times larger than widgets with a ratio equal to 1.
         ///
         /// @param widget  Pointer to the widget
         /// @param ratio   New ratio to set to the widget
         ///
-        /// @return True when the ratio was changed, false when the widget was not found
+        /// @return True if the ratio was changed, false if the widget was not found
         ///
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         bool setRatio(const Widget::Ptr& widget, float ratio);
 
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        /// @brief Change the ratio of a widget.
+        /// @brief Changes the ratio of a widget.
         /// The ratio is the size that will have a widget relatively to others. By default, the ratio is equal to 1.
-        /// So setting a ratio to 2 means that the widget will be 2 times larger than others.
+        ///
+        /// So setting a ratio to 2 means that the widget will be 2 times larger than widgets with a ratio equal to 1.
         ///
         /// @param index  Index of the widget in the layout
         /// @param ratio  New ratio to set to the widget
         ///
         /// If the index was too high then no change will be made
         ///
-        /// @return False when the index was too high
+        /// @return False if the index was too high
         ///
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         bool setRatio(std::size_t index, float ratio);
 
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        /// @brief Returns the ratio of a widget.
+        /// @brief Returns the ratio of a widget
         ///
         /// The ratio is the size that will have a widget relatively to others. By default, the ratio is equal to 1.
-        /// So setting a ratio to 2 means that the widget will be 2 times larger than others.
+        ///
+        /// So setting a ratio to 2 means that the widget will be 2 times larger than widgets with a ratio equal to 1.
         ///
         /// @param widget  Pointer to the widget
         ///
@@ -203,72 +206,73 @@ namespace tgui
 
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        /// @brief Returns the ratio of a widget.
+        /// @brief Returns the ratio of a widget
         ///
         /// The ratio is the size that will have a widget relatively to others. By default, the ratio is equal to 1.
-        /// So setting a ratio to 2 means that the widget will be 2 times larger than others.
+        ///
+        /// So setting a ratio to 2 means that the widget will be 2 times larger than widgets with a ratio equal to 1.
         ///
         /// @param index  Index of the widget in the layout
         ///
-        /// @return Ratio given to the widget or 0 when when the index was too high
+        /// @return Ratio given to the widget or 0 if the index was too high
         ///
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         float getRatio(std::size_t index);
 
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        /// @brief Set the size of a widget to a constant value.
+        /// @brief Set the size of a widget to a constant value
         ///
-        /// Setting a fixed size cancel the effect of the ratio.
+        /// Setting a fixed size cancels the effect of the ratio.
         /// If you want to get a variable size again for a widget, set the fixed size to 0.
         ///
         /// @param widget Pointer to the widget
         /// @param size   New fixed size of the widget
         ///
-        /// @return False when the widget was not found
+        /// @return False if the widget was not found
         ///
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         bool setFixedSize(const Widget::Ptr& widget, float size);
 
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        /// @brief Set the size of a widget to a constant value.
+        /// @brief Set the size of a widget to a constant value
         ///
-        /// Setting a fixed size cancel the effect of the ratio.
+        /// Setting a fixed size cancels the effect of the ratio.
         /// If you want to get a variable size again for a widget, set the fixed size to 0.
         ///
         /// @param index  Index of the widget in the layout
         /// @param size   New fixed size of the widget
         ///
-        /// @return False when the index was too high
+        /// @return False if the index was too high
         ///
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         bool setFixedSize(std::size_t index, float size);
 
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        /// @brief Returns the size of a widget when it has a constant value.
+        /// @brief Returns the size of a widget when it has a constant value
         ///
-        /// Having a fixed size cancel the effect of the ratio.
+        /// Having a fixed size cancels the effect of the ratio.
         /// When 0 is returned then the size of the widget is variable and determined by the ratio.
         ///
         /// @param widget Pointer to the widget
         ///
-        /// @return Fixed size of the widget or 0 when size is variable
+        /// @return Fixed size of the widget or 0 if size is variable
         ///
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         float getFixedSize(const Widget::Ptr& widget);
 
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        /// @brief Returns the size of a widget when it has a constant value.
+        /// @brief Returns the size of a widget when it has a constant value
         ///
-        /// Having a fixed size cancel the effect of the ratio.
+        /// Having a fixed size cancels the effect of the ratio.
         /// When 0 is returned then the size of the widget is variable and determined by the ratio.
         ///
         /// @param index  Index of the widget in the layout
         ///
-        /// @return Fixed size of the widget or 0 when size is variable or index is too high
+        /// @return Fixed size of the widget or 0 if size is variable or index is too high
         ///
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         float getFixedSize(std::size_t index);
@@ -300,7 +304,7 @@ namespace tgui
     protected:
 
         std::vector<float> m_widgetsRatio;              ///< The ratio of each widget.
-        std::vector<float> m_widgetsFixedSizes;         ///< The fixed size for each widget. 0 means a variable size.
+        std::vector<float> m_widgetsFixedSizes;         ///< The fixed size of each widget. 0 means a variable size.
 
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This PR fixes some spelling mistakes I made when I wrote this class. And also removes dots that shouldn't be there.

I also can do this work for your other classes, have a clean and consistent documentation is more comfortable for the reader.

If I do so, can you confirm that you use these conventions for the doc?
* Only long explanations end with a dot, other fields (`@brief`, `@param`) don't;
* Methods brief doc are written in the third person;
* Class briefs end with a dot;