### PR TITLE
ChildWindow Resizing Fix

### DIFF
--- a/src/TGUI/Widgets/ChildWindow.cpp
+++ b/src/TGUI/Widgets/ChildWindow.cpp
@@ -89,12 +89,12 @@ namespace tgui
 
         // Calculate the distance from the right side that the buttons will need
         float buttonOffsetX = 0;
-        if (m_closeButton->isVisible())
-            buttonOffsetX += (buttonOffsetX > 0 ? getRenderer()->m_paddingBetweenButtons : 0) + m_closeButton->getSize().x;
-        if (m_minimizeButton->isVisible())
-            buttonOffsetX += (buttonOffsetX > 0 ? getRenderer()->m_paddingBetweenButtons : 0) + m_minimizeButton->getSize().x;
-        if (m_maximizeButton->isVisible())
-            buttonOffsetX += (buttonOffsetX > 0 ? getRenderer()->m_paddingBetweenButtons : 0) + m_maximizeButton->getSize().x;
+        for (const auto& button : {m_closeButton, m_maximizeButton, m_minimizeButton})
+        {
+            if (button->isVisible())
+                buttonOffsetX += (buttonOffsetX > 0 ? getRenderer()->m_paddingBetweenButtons : 0) + button->getSize().x;
+        }
+
         if (buttonOffsetX > 0)
             buttonOffsetX += getRenderer()->m_distanceToSide;
 
@@ -562,23 +562,33 @@ namespace tgui
         // Check if you are resizing the window
         else if (m_mouseDown && m_resizeDirection != ResizeNone)
         {
+            float minimumWidth = 0;
+
+            for (const auto& button : {m_closeButton, m_maximizeButton, m_minimizeButton})
+            {
+                if (button->isVisible())
+                    minimumWidth += (minimumWidth > 0 ? getRenderer()->m_paddingBetweenButtons : 0) + button->getSize().x;
+            }
+
+            minimumWidth += 2 * getRenderer()->m_distanceToSide - getRenderer()->getBorders().left - getRenderer()->getBorders().right;
+
             if ((m_resizeDirection & ResizeLeft) != 0)
             {
                 float diff = x - getPosition().x;
-                if (getSize().x - diff >= 25)
+                if (getSize().x - diff >= minimumWidth)
                 {
                     setPosition(getPosition().x + diff, getPosition().y);
                     setSize(getSize().x - diff, getSize().y);
                 }
                 else
                 {
-                    setPosition(getPosition().x + getSize().x - 25, getPosition().y);
-                    setSize(25, getSize().y);
+                    setPosition(getPosition().x + getSize().x - minimumWidth, getPosition().y);
+                    setSize(minimumWidth, getSize().y);
                 }
             }
             else if ((m_resizeDirection & ResizeRight) != 0)
             {
-                setSize(std::max(25.0f, x - (getPosition().x + getRenderer()->m_borders.left)), getSize().y);
+                setSize(std::max(minimumWidth, x - (getPosition().x + getRenderer()->m_borders.left)), getSize().y);
             }
 
             if ((m_resizeDirection & ResizeBottom) != 0)
@@ -757,12 +767,12 @@ namespace tgui
         }
 
         float buttonOffsetX = 0;
-        if (m_closeButton->isVisible())
-            buttonOffsetX += (buttonOffsetX > 0 ? getRenderer()->m_paddingBetweenButtons : 0) + m_closeButton->getSize().x;
-        if (m_minimizeButton->isVisible())
-            buttonOffsetX += (buttonOffsetX > 0 ? getRenderer()->m_paddingBetweenButtons : 0) + m_minimizeButton->getSize().x;
-        if (m_maximizeButton->isVisible())
-            buttonOffsetX += (buttonOffsetX > 0 ? getRenderer()->m_paddingBetweenButtons : 0) + m_maximizeButton->getSize().x;
+        for (const auto& button : {m_closeButton, m_maximizeButton, m_minimizeButton})
+        {
+            if (button->isVisible())
+                buttonOffsetX += (buttonOffsetX > 0 ? getRenderer()->m_paddingBetweenButtons : 0) + button->getSize().x;
+        }
+
         if (buttonOffsetX > 0)
             buttonOffsetX += getRenderer()->m_distanceToSide;
 


### PR DESCRIPTION
With the recent additions to the ChildWindow I neglected to test resizing. Currently, you can resize a window with more than one button and the extra button(s) will hang off of the edge. This PR fixes this by only allowing the ChildWindow to be resized as small as the sum of the width of the buttons and their padding.

I also changed the way buttonOffsetX was determined (instead of each button hardcoded it loops more elegantly like your previous changes).

See here (red borders for dragging bounds):
![image](https://cloud.githubusercontent.com/assets/1320779/16673447/e482d924-4473-11e6-982e-6747c919c23c.png)




Unrelated, if I get time I may send another PR allowing the upper part of the window to resize (as it is now the title bar cannot be used to resize). This doesn't seem like a quick addition though, and some design changes may be required: currently the draggable area is defined by the renderer borders. This works okay, but I like to draw a single crisp pixel around the window and clicking a single pixel to drag is very difficult. What I propose is keep the borders strictly for drawing and having another function, something such as setResizeWidth(std::size_t pixels), that allows us to split the drawing borders and the draggable area borders. Furthermore, there may be instances that being able to resize in only one plane desirable. Something such as setResizePlanes(Resize::Vertical) would only allow vertical resizing. What are your thoughts on this before I start playing around?

Edit: On second thought I'm not sure that the plane thing is necessary. I thought I had a good use in mind for it but it doesn't seem like something that's all that useful. 