### PR TITLE
Allow the ChildWindow to have maximum and minimum sizes.

### DIFF
--- a/include/TGUI/Widgets/ChildWindow.hpp
+++ b/include/TGUI/Widgets/ChildWindow.hpp
@@ -152,6 +152,52 @@ namespace tgui
 
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        /// @brief Returns the maximum size of the child window.
+        ///
+        /// @return Maximum size of the child window
+        ///
+        /// The size returned by this function is the maximum size of the child window, excluding the title bar and the borders.
+        ///
+        /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        sf::Vector2f getMaximumSize() const;
+
+
+        /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        /// @brief Returns the minimum size of the child window.
+        ///
+        /// @return Minimum size of the child window
+        ///
+        /// The size returned by this function is the minimum size of the child window, excluding the title bar and the borders.
+        ///
+        /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        sf::Vector2f getMinimumSize() const;
+
+
+        /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        /// @brief Sets the maximum size of the child window.
+        ///
+        /// @param size   Sets the new maximum size of the child window
+        ///
+        /// This function sets the maximum size of the window excluding borders and titlebar. If the window is larger than the new
+        /// maximum size, it will automatically be resized down.
+        ///
+        /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        void setMaximumSize(sf::Vector2f size);
+
+
+        /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        /// @brief Sets the minimum size of the child window.
+        ///
+        /// @param size   Sets the new minimum size of the child window
+        ///
+        /// This function sets the minimum size of the window excluding borders and titlebar. If the window is smaller than the new
+        /// minimum size, it will automatically be resized up.
+        ///
+        /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        void setMinimumSize(sf::Vector2f size);
+
+
+        /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         /// @brief Changes the font of the text in the widget and its children.
         ///
         /// @param font  The new font.
@@ -502,6 +548,8 @@ namespace tgui
 
         Label          m_titleText;
         sf::Vector2f   m_draggingPosition;
+        sf::Vector2f   m_maximumSize;
+        sf::Vector2f   m_minimumSize;
         TitleAlignment m_titleAlignment = TitleAlignment::Center;
         TitleButtons   m_titleButtons = TitleButtons::Close;
         sf::String     m_closeButtonText = "x";
@@ -514,6 +562,8 @@ namespace tgui
 
         bool m_mouseDownOnTitleBar = false;
         bool m_keepInParent = false;
+        bool m_maximumSizeSet = false;
+        bool m_minimumSizeSet = false;
 
         bool m_resizable = false;
         int m_resizeDirection = ResizeNone;


### PR DESCRIPTION
Alright, so this allows the user to explicitly set a ChildWindow's minimum and maximum sizes when resizing by dragging the edges. It's easiest to test by modifying the ChildWindow theme properties to something like:
```
ChildWindow {
    BorderColor     : rgb(255, 0, 0);
    Borders         : (4, 4, 4, 4);
}
```

Some behavioral decisions:
- setSize() does not respect any previously set maximum/minimum sizes
- Resizing width will stop to keep the buttons within the titlebar even if the set minimum size is smaller. For example, a ChildWindow with 2 buttons may require a minimum of 50 pixels to keep the buttons on the titlebar properly. If you set the minimum width of the ChildWindow to be 30, the window will not be resized below 50.
- Negative values are allowed and not checked for. Per @texus: "I consider negative size undefined behavior in widgets"


The main.cpp code for testing is a bit sloppy, but on [pastebin](http://pastebin.com/raw/YE5m2tpr) for convenience. 