### PR TITLE
Change use of std::not1 and std::ptr_fun to use lambdas

### DIFF
--- a/src/TGUI/Global.cpp
+++ b/src/TGUI/Global.cpp
@@ -165,8 +165,8 @@ namespace tgui
 
     std::string trim(std::string str)
     {
-        str.erase(str.begin(), std::find_if(str.begin(), str.end(), std::not1(std::ptr_fun<int, int>(std::isspace))));
-        str.erase(std::find_if(str.rbegin(), str.rend(), std::not1(std::ptr_fun<int, int>(std::isspace))).base(), str.end());
+        str.erase(str.begin(), std::find_if(str.begin(), str.end(), [](int c) { return !isspace(c); }));
+        str.erase(std::find_if(str.rbegin(), str.rend(), [](int c) { return !isspace(c); }).base(), str.end());
         return str;
     }
 

--- a/src/TGUI/Global.cpp
+++ b/src/TGUI/Global.cpp
@@ -165,8 +165,8 @@ namespace tgui
 
     std::string trim(std::string str)
     {
-        str.erase(str.begin(), std::find_if(str.begin(), str.end(), [](int c) { return !isspace(c); }));
-        str.erase(std::find_if(str.rbegin(), str.rend(), [](int c) { return !isspace(c); }).base(), str.end());
+        str.erase(str.begin(), std::find_if(str.begin(), str.end(), [](int c) { return !std::isspace(c); }));
+        str.erase(std::find_if(str.rbegin(), str.rend(), [](int c) { return !std::isspace(c); }).base(), str.end());
         return str;
     }
 


### PR DESCRIPTION
Changing the use of std::not1 and std::ptr_fun to use lambdas, since c++17 seems to have deprecated the binders, adapters, and negators (except std::not_fn, which was added) in ```<functional>```.  TGUI will still compile for me if I don't use the ```/std:c++17``` or ```/std:c++latest``` flags, but it should be more future-proof now.

2nd commit is because I forgot to add ```std::``` before isspace.  I added it back to remain consistent with the original code.