### PR TITLE
allow TGUI to be build simultaneously with SFML

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,31 +206,28 @@ if(NOT TGUI_SHARED_LIBS)
     endif()
 endif()
 
+# Find sfml if not build in same project
+if(NOT TARGET sfml-graphics)
+    if(TGUI_OS_WINDOWS AND TGUI_COMPILER_MSVC) # Also look for the main component when using Visual Studio
+        find_package(SFML 2 COMPONENTS main graphics window system)
+    elseif(TGUI_OS_ANDROID)  # Search for SFML in the android NDK (if no other directory is specified)
+        find_package(SFML 2 COMPONENTS graphics window system PATHS "${CMAKE_ANDROID_NDK}/sources/third_party/sfml/lib/${CMAKE_ANDROID_ARCH_ABI}/cmake/SFML")
+    elseif(TGUI_OS_IOS)  # Use the find_host_package macro from the toolchain on iOS
+        find_host_package(SFML 2 COMPONENTS main graphics window system)
+    else()
+        find_package(SFML 2 COMPONENTS graphics window system)
+    endif()
 
-if(TARGET sfml-window)
-    message("Using in place build")
-else()
-# Find sfml
-if(TGUI_OS_WINDOWS AND TGUI_COMPILER_MSVC) # Also look for the main component when using Visual Studio
-    find_package(SFML 2 COMPONENTS main graphics window system)
-elseif(TGUI_OS_ANDROID)  # Search for SFML in the android NDK (if no other directory is specified)
-    find_package(SFML 2 COMPONENTS graphics window system PATHS "${CMAKE_ANDROID_NDK}/sources/third_party/sfml/lib/${CMAKE_ANDROID_ARCH_ABI}/cmake/SFML")
-elseif(TGUI_OS_IOS)  # Use the find_host_package macro from the toolchain on iOS
-    find_host_package(SFML 2 COMPONENTS main graphics window system)
-else()
-    find_package(SFML 2 COMPONENTS graphics window system)
-endif()
-
-# find_package couldn't find SFML
-if(NOT SFML_FOUND)
-    set(SFML_DIR "" CACHE PATH "Path to SFMLConfig.cmake")
-    set(SFML_ROOT "" CACHE PATH "SFML root directory")
-    message(FATAL_ERROR "CMake couldn't find SFML.\nEither set SFML_DIR to the directory containing SFMLConfig.cmake or set the SFML_ROOT entry to SFML's root directory (containing \"include\" and \"lib\" directories).")
+    # find_package couldn't find SFML
+    if(NOT SFML_FOUND)
+        set(SFML_DIR "" CACHE PATH "Path to SFMLConfig.cmake")
+        set(SFML_ROOT "" CACHE PATH "SFML root directory")
+        message(FATAL_ERROR "CMake couldn't find SFML.\nEither set SFML_DIR to the directory containing SFMLConfig.cmake or set the SFML_ROOT entry to SFML's root directory (containing \"include\" and \"lib\" directories).")
+    endif()
 endif()
 
 # Set the path for the libraries
 set(LIBRARY_OUTPUT_PATH "${PROJECT_BINARY_DIR}/lib")
-endif()
 
 # Jump to the CMakeLists.txt file in the source folder
 add_subdirectory(src/TGUI)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,10 @@ if(NOT TGUI_SHARED_LIBS)
     endif()
 endif()
 
+
+if(TARGET sfml-window)
+    message("Using in place build")
+else()
 # Find sfml
 if(TGUI_OS_WINDOWS AND TGUI_COMPILER_MSVC) # Also look for the main component when using Visual Studio
     find_package(SFML 2 COMPONENTS main graphics window system)
@@ -226,6 +230,7 @@ endif()
 
 # Set the path for the libraries
 set(LIBRARY_OUTPUT_PATH "${PROJECT_BINARY_DIR}/lib")
+endif()
 
 # Jump to the CMakeLists.txt file in the source folder
 add_subdirectory(src/TGUI)


### PR DESCRIPTION
The idea is following:

i have following git repo:

SFML (submodule to 2.5.x branch)
TGUI (submodule to 0.8 branch)
awesome_game (actual source code)
CMakeLists.txt

this patch allows sth like this in CMakeLists.txt:
```
add_subdirectory(SFML)
add_subdirectory(TGUI)
include_directories(
   ${SFML_SOURCE_DIR}/include
   ${TGUI_SOURCE_DIR}/include
)
add_subdirectory(awesome_game)
```

Perhaps, instead of autodetection, one could use an option