### PR TITLE
Recalculate tabs width after removing

### DIFF
--- a/src/TGUI/Widgets/Tabs.cpp
+++ b/src/TGUI/Widgets/Tabs.cpp
@@ -277,6 +277,7 @@ namespace tgui
 
         // New hovered tab depends on several factors, we keep it simple and just remove the hover state
         m_hoveringTab = -1;
+        recalculateTabsWidth();
         return true;
     }
 


### PR DESCRIPTION
For some reason remove is not calling recalculateTabsWidth(), opposite for all others modify operations. 