### PR TITLE
Update spin value periodically if left mouse pressed is been holding

### DIFF
--- a/include/TGUI/Widgets/SpinButton.hpp
+++ b/include/TGUI/Widgets/SpinButton.hpp
@@ -29,6 +29,7 @@
 
 #include <TGUI/Renderers/SpinButtonRenderer.hpp>
 #include <TGUI/Widgets/ClickableWidget.hpp>
+#include <TGUI/Timer.hpp>
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -95,7 +96,7 @@ namespace tgui
         ///
         /// @param size  The new size of the spin button
         ///
-        /// Note that the VerticalScroll propery is changed by this function based on the given width and height.
+        /// Note that the VerticalScroll property is changed by this function based on the given width and height.
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         void setSize(const Layout2d& size) override;
         using Widget::setSize;
@@ -280,6 +281,12 @@ namespace tgui
 
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    private:
+
+        void CallMousePressPeriodically(std::chrono::time_point<std::chrono::steady_clock> clicked);
+
+
+        /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     public:
 
         SignalFloat onValueChange = {"ValueChanged"}; //!< Value of the spin button changed. Optional parameter: new value
@@ -290,6 +297,7 @@ namespace tgui
 
         // Is the spin button draw vertically (arrows on top of each other)?
         bool m_verticalScroll = true;
+        std::chrono::time_point<std::chrono::steady_clock> m_PressedAt;
 
         float m_minimum = 0;
         float m_maximum = 10;

--- a/src/TGUI/Widgets/SpinButton.cpp
+++ b/src/TGUI/Widgets/SpinButton.cpp
@@ -544,25 +544,31 @@ namespace tgui
 
     void SpinButton::CallMousePressPeriodically(std::chrono::time_point<std::chrono::steady_clock> clicked)
     {
-        tgui::Timer::scheduleCallback([this, clicked]()
+        Timer::scheduleCallback([widget = shared_from_this(), clicked]()
+        {
+            SpinButton::Ptr spinButton = std::static_pointer_cast<SpinButton>(widget);
+            if (spinButton)
             {
                 // Mouse still over and the mouse press is current
-                if (!m_mouseHover || !m_mouseDown || m_PressedAt != clicked)
+                if (!spinButton->m_mouseHover || !spinButton->m_mouseDown || spinButton->m_PressedAt != clicked)
                 {
                     return;
                 }
 
-                if (m_value < m_maximum && m_mouseDownOnTopArrow && m_mouseHoverOnTopArrow)
+                if (spinButton->m_value < spinButton->m_maximum &&
+                    spinButton->m_mouseDownOnTopArrow && spinButton->m_mouseHoverOnTopArrow)
                 {
-                    setValue(m_value + m_step);
-                    CallMousePressPeriodically(clicked);
+                    spinButton->setValue(spinButton->m_value + spinButton->m_step);
+                    spinButton->CallMousePressPeriodically(clicked);
                 }
-                else if (m_value > m_minimum && !m_mouseDownOnTopArrow && !m_mouseHoverOnTopArrow)
+                else if (spinButton->m_value > spinButton->m_minimum &&
+                    !spinButton->m_mouseDownOnTopArrow && !spinButton->m_mouseHoverOnTopArrow)
                 {
-                    setValue(m_value - m_step);
-                    CallMousePressPeriodically(clicked);
+                    spinButton->setValue(spinButton->m_value - spinButton->m_step);
+                    spinButton->CallMousePressPeriodically(clicked);
                 }
-            }, std::chrono::milliseconds(300));
+            }
+        }, std::chrono::milliseconds(300));
     }
 
     /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/tests/Widgets/SpinButton.cpp
+++ b/tests/Widgets/SpinButton.cpp
@@ -172,12 +172,9 @@ TEST_CASE("[SpinButton]")
             parent->add(spinButton);
 
             parent->leftMousePressed({110, 100});
-            REQUIRE(valueChangedCount == 1);
-            REQUIRE(spinButton->getValue() == 10);
-
-            parent->leftMouseReleased({110, 100});
             REQUIRE(valueChangedCount == 2);
             REQUIRE(spinButton->getValue() == 11);
+            parent->leftMouseReleased({110, 100});
 
             parent->leftMousePressed({110, 135});
             parent->leftMouseReleased({110, 135});

--- a/tests/Widgets/SpinControl.cpp
+++ b/tests/Widgets/SpinControl.cpp
@@ -148,12 +148,9 @@ TEST_CASE("[spinControl]")
             parent->add(spinControl);
 
             parent->leftMousePressed({110, 100});
-            REQUIRE(valueChangedCount == 1);
-            REQUIRE(spinControl->getValue() == 10);
-
-            parent->leftMouseReleased({110, 100});
             REQUIRE(valueChangedCount == 2);
             REQUIRE(spinControl->getValue() == 11);
+            parent->leftMouseReleased({110, 100});
 
             parent->leftMousePressed({110, 135});
             parent->leftMouseReleased({110, 135});


### PR DESCRIPTION
I'm not sure that Timer::scheduleCallback is the right choice here, but idea is simple - move changing value from mouse release handler to mouse pressed handler and to call changer periodically while some conditions (mouse still pressed, mouse still hover on widget and correct spin button and there wasn't any new clicks) are still being true. 