### PR TITLE
Added possibility to sort widgets.

### DIFF
--- a/include/TGUI/Container.hpp
+++ b/include/TGUI/Container.hpp
@@ -107,6 +107,19 @@ namespace tgui
             return m_widgets;
         }
 
+        /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        /// @brief Sorts a list of all the widgets in this container
+        ///
+        /// @param function comparison function object (i.e. an object that satisfies the requirements of Compare) which
+        ///                 returns true if the first argument is less than (i.e. is ordered before) the second.
+        ///
+        /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        template<typename Function>
+        void sortWidgets(Function&& function)
+        {
+            std::sort(m_widgets.begin(), m_widgets.end(), std::forward<Function>(function));
+        }
+
 #ifndef TGUI_REMOVE_DEPRECATED_CODE
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         /// @brief Returns a list of the names of all the widgets in this container

--- a/tests/Container.cpp
+++ b/tests/Container.cpp
@@ -230,6 +230,22 @@ TEST_CASE("[Container]")
         REQUIRE(widget3->getWidgetName() == "w003");
     }
 
+    SECTION("sortWidgets")
+    {
+        REQUIRE(container->getWidgets().size() == 3);
+        widget1->setWidgetName("1");
+        widget2->setWidgetName("2");
+        widget3->setWidgetName("3");
+
+        container->getContainer()->sortWidgets([](const tgui::Widget::Ptr& p, const tgui::Widget::Ptr& p2){
+            return p->getWidgetName()[0] < p2->getWidgetName()[0];
+        });
+
+        REQUIRE(container->getWidgets()[0] == widget1);
+        REQUIRE(container->getWidgets()[1] == widget2);
+        REQUIRE(container->getWidgets()[2] == widget3);
+    }
+
     SECTION("focus")
     {
         auto editBox1 = tgui::EditBox::create();


### PR DESCRIPTION
Added possibility to sort Container::m_widgets by std::sort and user lambda compare function to further enable moving widgets.

In example now can I sort layers of widgets and change what should be first displayed in one command and not by calling moveWidgetForward or moveWidgetBackward