### PR TITLE
Use fromNumberRounded in SpinControl

### DIFF
--- a/src/Widgets/SpinControl.cpp
+++ b/src/Widgets/SpinControl.cpp
@@ -53,7 +53,7 @@ namespace tgui
         spinControl->setMinimum(min);
         spinControl->setMaximum(max);
         spinControl->setValue(value);
-        spinControl->setString(String(value));
+        spinControl->setString(String::fromNumberRounded(value, decimal));
         spinControl->setDecimalPlaces(decimal);
         spinControl->setStep(step);
         return spinControl;
@@ -178,7 +178,7 @@ namespace tgui
         if (m_spinButton->getValue() != value && inRange(value))
         {
             m_spinButton->setValue(value);
-            setString(String(value));
+            setString(String::fromNumberRounded(value, m_decimalPlaces));
             return true;
         }
         return false;
@@ -210,7 +210,7 @@ namespace tgui
     void SpinControl::setDecimalPlaces(unsigned decimalPlaces)
     {
         m_decimalPlaces = decimalPlaces;
-        setString(String(getValue()));
+        setString(String::fromNumberRounded(getValue(), m_decimalPlaces));
     }
 
     /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -242,7 +242,7 @@ namespace tgui
         m_spinButton = m_container->get<tgui::SpinButton>("SpinButton");
 
         init();
-        setString(String(m_spinButton->getValue()));
+        setString(String::fromNumberRounded(m_spinButton->getValue(), m_decimalPlaces));
     }
 
     /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -251,7 +251,7 @@ namespace tgui
     {
         m_spinButton->setPosition(bindRight(m_spinText), bindTop(m_spinText));
         m_spinButton->onValueChange([this](const float val) {
-            setString(String(val));
+            setString(String::fromNumberRounded(val, m_decimalPlaces));
             onValueChange.emit(this, val);
         });
 
@@ -261,17 +261,17 @@ namespace tgui
             const float val = text.toFloat(defValue);
             if (val == defValue || !inRange(val))
             {
-                setString(String(curValue));
+                setString(String::fromNumberRounded(curValue, m_decimalPlaces));
             }
             else if (curValue != val)
             {
                 m_spinButton->setValue(val);
 
                 // Display actual value because SpinButton can round entered number
-                setString(String(m_spinButton->getValue()));
+                setString(String::fromNumberRounded(m_spinButton->getValue(), m_decimalPlaces));
             }
             else
-                setString(text);
+                setString(String::fromNumberRounded(val, m_decimalPlaces));
         });
 
         const auto buttonSize = m_spinButton->getSize();
@@ -290,33 +290,7 @@ namespace tgui
 
     void SpinControl::setString(const String& str)
     {
-        const auto pos = str.find('.');
-        const auto integerPart = str.substr(0, pos);
-        if (m_decimalPlaces == 0)
-        {
-            m_spinText->setText(integerPart);
-            return;
-        }
-
-        String floatPart = ".";
-        if (pos != String::npos)
-        {
-            floatPart = str.substr(pos);
-        }
-        const auto len = floatPart.size() - 1;
-
-        if (len < m_decimalPlaces)
-        {
-            m_spinText->setText(integerPart + floatPart + String(m_decimalPlaces - len, '0'));
-        }
-        else if (len == m_decimalPlaces)
-        {
-            m_spinText->setText(str);
-        }
-        else
-        {
-            m_spinText->setText(integerPart + floatPart.substr(pos, m_decimalPlaces + 1));
-        }
+        m_spinText->setText(str);
     }
 
     /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/tests/Layouts.cpp
+++ b/tests/Layouts.cpp
@@ -25,6 +25,7 @@
 #include "Tests.hpp"
 #include <TGUI/Widgets/Button.hpp>
 #include <TGUI/Widgets/Panel.hpp>
+#include <iostream>
 
 using namespace tgui::bind_functions;
 using tgui::Layout;

--- a/tests/String.cpp
+++ b/tests/String.cpp
@@ -1329,6 +1329,13 @@ TEST_CASE("[String]")
         REQUIRE(tgui::String::fromNumber(0.5) == "0.5");
     }
 
+    SECTION("fromNumberRounded")
+    {
+        REQUIRE(tgui::String::fromNumberRounded(15.001f, 0) == "15");
+        REQUIRE(tgui::String::fromNumberRounded(-3.0015f, 3) == "-3.001");
+        REQUIRE(tgui::String::fromNumberRounded(0.5f, 2) == "0.50");
+    }
+
     SECTION("trim")
     {
         str = "\t xyz\r\n";

--- a/tests/Widget.cpp
+++ b/tests/Widget.cpp
@@ -28,6 +28,7 @@
 #include <TGUI/Widgets/Label.hpp>
 #include <TGUI/Widgets/CheckBox.hpp>
 #include <TGUI/Widgets/EditBox.hpp>
+#include <iostream>
 
 TEST_CASE("[Widget]")
 {


### PR DESCRIPTION
There was a bug in setString method in [this line](https://github.com/texus/TGUI/blob/v0.9.1/src/Widgets/SpinControl.cpp#L318). Instead of pos should be 0. But as tgui::String already contains function for float to string convertation I updated code correspondingly. 
Also added tests for fromNumberRounded.