### PR TITLE
Update DataIO.cpp

### DIFF
--- a/src/Loading/DataIO.cpp
+++ b/src/Loading/DataIO.cpp
@@ -408,15 +408,15 @@ namespace tgui
                 }
 
                 REMOVE_WHITESPACE_AND_COMMENTS(true)
-                if (stream.peek() == '{')
+                if (stream.peek() == '=')
                 {
-                    const String error = parseSection(stream, sectionNode, word);
+                    const String error = parseKeyValue(stream, sectionNode, word);
                     if (!error.empty())
                         return error;
                 }
-                else if (stream.peek() == '=')
+                else if (stream.peek() == '{')
                 {
-                    const String error = parseKeyValue(stream, sectionNode, word);
+                    const String error = parseSection(stream, sectionNode, word);
                     if (!error.empty())
                         return error;
                 }
@@ -503,10 +503,10 @@ namespace tgui
             }
 
             REMOVE_WHITESPACE_AND_COMMENTS(true)
-            if (stream.peek() == '{')
-                return parseSection(stream, root, word);
-            else if (stream.peek() == '=')
+            if (stream.peek() == '=')
                 return parseKeyValue(stream, root, word);
+            else if (stream.peek() == '{')
+                return parseSection(stream, root, word);
             else if (stream.peek() == ':')
                 return parseInheritance(stream, root, word);
             else

--- a/src/Loading/DataIO.cpp
+++ b/src/Loading/DataIO.cpp
@@ -420,6 +420,12 @@ namespace tgui
                     if (!error.empty())
                         return error;
                 }
+                else if (stream.peek() == ':')
+                {
+                    const String error = parseInheritance(stream, sectionNode, word);
+                    if (!error.empty())
+                        return error;
+                }
                 else
                     return "Expected '{' or '=', found '" + String(1, static_cast<char>(stream.peek())) + "' instead.";
             }


### PR DESCRIPTION
As it stood, the attribute inheritance feature did not work for arbitrary sections. Even the theme Black.txt used in an example could not be parsed, and the program would exit with an exception once the first colon character was encountered. I suspect this fix to the parseSection function should allow it to recognize the inheritance operator in theme files.