### PR TITLE
Fix namespace issue in RendererDefines.hpp

### DIFF
--- a/include/TGUI/RendererDefines.hpp
+++ b/include/TGUI/RendererDefines.hpp
@@ -74,7 +74,7 @@
     } \
     void CLASS::set##NAME(tgui::TextStyles style) \
     { \
-        setProperty(tgui::String(#NAME), ObjectConverter{style}); \
+        setProperty(tgui::String(#NAME), tgui::ObjectConverter{style}); \
     }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -93,7 +93,7 @@
     TGUI_RENDERER_PROPERTY_GET_NUMBER(CLASS, NAME, DEFAULT) \
     void CLASS::set##NAME(float number) \
     { \
-        setProperty(tgui::String(#NAME), ObjectConverter{number}); \
+        setProperty(tgui::String(#NAME), tgui::ObjectConverter{number}); \
     }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -112,7 +112,7 @@
     TGUI_RENDERER_PROPERTY_GET_BOOL(CLASS, NAME, DEFAULT) \
     void CLASS::set##NAME(bool flag) \
     { \
-        setProperty(tgui::String(#NAME), ObjectConverter{flag}); \
+        setProperty(tgui::String(#NAME), tgui::ObjectConverter{flag}); \
     }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Hey, 
I fixed an issue with a missing namespace in RendererDefines.hpp.

I got the following error in a Custom Renderer implementation:
```
error: use of undeclared identifier 'ObjectConverter'
[build] TGUI_RENDERER_PROPERTY_NUMBER(NavigationContainerRenderer, NavigationBarHeight, 0)
[build] ^
[build] In file included from ./src/gui/Widgets/NavigationContainerRenderer.cpp:10:
[build] ./TGUI/RendererDefines.hpp:96:42: note: expanded from macro 'TGUI_RENDERER_PROPERTY_NUMBER'
[build]         setProperty(tgui::String(#NAME), ObjectConverter{number}); \
[build]                                          ^
[build] 1 error generated.
```