### PR TITLE
Add missing include in include/TGUI/Utf.hpp

### DIFF
--- a/include/TGUI/Utf.hpp
+++ b/include/TGUI/Utf.hpp
@@ -29,6 +29,7 @@
 #include <TGUI/Config.hpp>
 
 #if !TGUI_EXPERIMENTAL_USE_STD_MODULE
+    #include <cstdint>
     #include <string>
     #include <array>
 #endif


### PR DESCRIPTION
When building with `g++ 13.1.1` there is a compilation error because the definition of `std::uint8_t` is missing.

This patch adds `#include <cstdint>`.