### PR TITLE
Fixed widgets not being updated in BoxLayout when a child widget's index was changed using setWidgetIndex (fixes #202)

### DIFF
--- a/include/TGUI/Container.hpp
+++ b/include/TGUI/Container.hpp
@@ -345,7 +345,7 @@ TGUI_MODULE_EXPORT namespace tgui
         ///
         /// @return True when the index was changed, false if widget wasn't found in the container or index was too high
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        bool setWidgetIndex(const Widget::Ptr& widget, std::size_t index);
+        virtual bool setWidgetIndex(const Widget::Ptr& widget, std::size_t index);
 
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/include/TGUI/Widgets/BoxLayout.hpp
+++ b/include/TGUI/Widgets/BoxLayout.hpp
@@ -138,6 +138,20 @@ TGUI_MODULE_EXPORT namespace tgui
 
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        /// @brief Changes the index of a widget in this container
+        ///
+        /// Widgets are drawn in the order of the list, so widgets with a higher index will appear after others.
+        ///
+        /// @param widget  Widget that is to be moved to a different index
+        /// @param index   New index of the widget, corresponding to the widget position after the widget has been moved
+        ///
+        /// @return True when the index was changed, false if widget wasn't found in the container or index was too high
+        /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        virtual bool setWidgetIndex(const Widget::Ptr& widget, std::size_t index) override;
+        using Container::setWidgetIndex;
+
+
+        /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     protected:
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/Widgets/BoxLayout.cpp
+++ b/src/Widgets/BoxLayout.cpp
@@ -131,6 +131,16 @@ namespace tgui
 
     /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+    bool BoxLayout::setWidgetIndex(const Widget::Ptr& widget, std::size_t index)
+    {
+        const auto widgetIndexChanged = Container::setWidgetIndex(widget, index);
+        if (widgetIndexChanged)
+            updateWidgets();
+        return widgetIndexChanged;
+    }
+
+    /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
     void BoxLayout::rendererChanged(const String& property)
     {
         if (property == U"SpaceBetweenWidgets")


### PR DESCRIPTION
Previously, when a widget within a `BoxLayout`-derived container (`HorizontalLayout`, `VerticalLayout`, `HorizontalWrap`) had its index changed via `Container::setWidgetIndex()`, it would not update the widgets in the `BoxLayout` using `updateWidgets()`. This would cause the widget to appear not to have been assigned a new index, until `updateWidgets()` was called in some other way (for example, when the `BoxLayout` gained a new widget, or if the `BoxLayout` was resized).

Now, `Container::setWidgetIndex()` is virtual, and `BoxLayout` overrides it. The overridden implementation invokes `Container::setWidgetIndex()`, and returns the result of the call. If the result of that call is `true`, the index change was successful, so `updateWidgets()` is called to show the change in the index immediately.