### PR TITLE
EditBox: Add onCaretPositionChange Signal and Fix Bugs in EditBox::selectText()

### DIFF
--- a/include/TGUI/Widgets/EditBox.hpp
+++ b/include/TGUI/Widgets/EditBox.hpp
@@ -607,6 +607,7 @@ TGUI_MODULE_EXPORT namespace tgui
         SignalString             onReturnOrUnfocus     = {"ReturnOrUnfocused"};    //!< The return key was pressed or the edit box was unfocused. Optional parameter: text in the edit box
         SignalTyped<std::size_t> onCaretPositionChange = {"CaretPositionChanged"}; //!< The caret's position was changed. Optional parameter: new caret position
 
+
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     protected:
 

--- a/include/TGUI/Widgets/EditBox.hpp
+++ b/include/TGUI/Widgets/EditBox.hpp
@@ -544,6 +544,13 @@ TGUI_MODULE_EXPORT namespace tgui
 
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        // Updates m_selEnd with a new value and emits the onCaretPositionChange signal
+        // @param newValue the value to assign to m_selEnd.
+        /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        void updateSelEnd(const std::size_t newValue);
+
+
+        /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     private:
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -595,10 +602,10 @@ TGUI_MODULE_EXPORT namespace tgui
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     public:
 
-        SignalString onTextChange     = {"TextChanged"};        //!< The text was changed. Optional parameter: new text
-        SignalString onReturnKeyPress = {"ReturnKeyPressed"};   //!< The return key was pressed. Optional parameter: text in the edit box
-        SignalString onReturnOrUnfocus = {"ReturnOrUnfocused"}; //!< The return key was pressed or the edit box was unfocused. Optional parameter: text in the edit box
-
+        SignalString             onTextChange          = {"TextChanged"};          //!< The text was changed. Optional parameter: new text
+        SignalString             onReturnKeyPress      = {"ReturnKeyPressed"};     //!< The return key was pressed. Optional parameter: text in the edit box
+        SignalString             onReturnOrUnfocus     = {"ReturnOrUnfocused"};    //!< The return key was pressed or the edit box was unfocused. Optional parameter: text in the edit box
+        SignalTyped<std::size_t> onCaretPositionChange = {"CaretPositionChanged"}; //!< The caret's position was changed. Optional parameter: new caret position
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     protected:

--- a/src/Widgets/EditBox.cpp
+++ b/src/Widgets/EditBox.cpp
@@ -186,8 +186,8 @@ namespace tgui
 
     void EditBox::selectText(std::size_t start, std::size_t length)
     {
-        m_selStart = start;
-        updateSelEnd(std::min(m_text.length(), start + length));
+        m_selStart = std::min(m_text.length(), start);
+        updateSelEnd(length == String::npos ? m_text.length() : std::min(m_text.length(), start + length));
         updateSelection();
     }
 


### PR DESCRIPTION
After completing extensive testing I've concluded that the new `onCaretPositionChange` signal added to `EditBox` can be merged, barring any additional comments. Here are most of the tests I carried out, which also help describe how the signal operates:

| Test Case | Actions | Result |
| --- | --- | --- |
| moveCaretWordEnd | move caret to end of last word | emitted
| moveCaretWordEnd | move caret to end of non-last word | emitted
| moveCaretWordBegin | move caret to beginning of first word | emitted
| moveCaretWordBegin | move caret to beginning of non-first word | emitted
| moveCaretRight | highlighted text, caret on right side | does not emit as caret does not change position
| moveCaretRight | highlighted text, caret on left side | emitted
| moveCaretRight | no highlighted text, caret in middle/start of text | emitted
| moveCaretRight | no highlighted text, caret at end of text | does not emit
| moveCaretLeft | highlighted text, caret on right side | emitted
| moveCaretLeft | highlighted text, caret on left side | does not emit
| moveCaretLeft | no highlighted text, caret in middle/end of text | emitted
| moveCaretLeft | no highlighted text, caret at beginning of text | does not emit
| keyPressed(DocumentBegin OR PageUp OR Up) | caret at beginning of text | does not emit
| keyPressed(DocumentBegin OR PageUp OR Up) | caret at middle/end of text | emitted
| keyPressed(DocumentEnd OR PageDown OR Down) | caret at end of text | does not emit
| keyPressed(DocumentEnd OR PageDown OR Down) | caret at middle/start of text | emitted
| mouseMoved | no fixed width | emitted once for every new character selected or deselected
| mouseMoved | fixed width | ditto
| leftMousePressed | double click on caret at end of text | does not emit
| leftMousePressed | other double click cases | emits twice, one for the single click and one for the double click
| leftMousePressed | single clicks | emitted, unless you click on the caret
| setCaretPosition | calls to this method from within EditBox all work as expected; setMaximumCharacters() if it causes to move caret; Selecting and pasting, pasting, cutting, etc. all work, and the text is always updated before the signal is emitted; Fixed width works as expected
| setCaretPosition | different position | emitted
| setCaretPosition | same position | does not emit
| selectText | select different range | emitted
| selectText | select same range | does not emit
| selectText | select range that causes caret to be at the same end position | does not emit

I've also identified two cases where giving out-of-bounds values to `EditBox::selectText()` would cause crashes and/or unexpected behaviour:

1. If you set `start` to be greater than the length of the text, an out-of-bounds string exception would be thrown. Capping `start` to the size of the text prevents this from occurring, and it will mean that no text is selected.
2. Previously, if you set `start` to a non-0 value, but left `length` to its default `npos` value, it would cause an overflow in the `start + length` calculation which would mean that `selectText(1)` would select the first character of the text, and would not start at the second character and select the rest of the text (since `npos + 1` would overflow to `0`). As far as I can tell this does not seem like the intended behaviour, so I've added some code that always explicitly sets the end of the selection to the end of the text when `npos` is given to `length`. You could still cause overflows now but you'd have to go out of your way to do it.