### PR TITLE
TextArea: Add getCaretLine(), getCaretColumn(), and onCaretPositionChange Signal. String: Add count() methods

### DIFF
--- a/include/TGUI/String.hpp
+++ b/include/TGUI/String.hpp
@@ -873,6 +873,11 @@ TGUI_MODULE_EXPORT namespace tgui
         TGUI_NODISCARD inline bool ends_with(char16_t ch) const noexcept;
         TGUI_NODISCARD inline bool ends_with(char32_t ch) const noexcept;
 
+        TGUI_NODISCARD std::size_t count(const char ch, const std::size_t pos = npos) const noexcept;
+        TGUI_NODISCARD std::size_t count(const wchar_t ch, const std::size_t pos = npos) const noexcept;
+        TGUI_NODISCARD std::size_t count(const char16_t ch, const std::size_t pos = npos) const noexcept;
+        TGUI_NODISCARD std::size_t count(const char32_t ch, const std::size_t pos = npos) const noexcept;
+
         inline friend bool operator==(const String& left, StringView right);
         inline friend bool operator==(const String& left, const char32_t* right);
         inline friend bool operator==(const String& left, const std::u32string& right);

--- a/include/TGUI/String.hpp
+++ b/include/TGUI/String.hpp
@@ -873,10 +873,10 @@ TGUI_MODULE_EXPORT namespace tgui
         TGUI_NODISCARD inline bool ends_with(char16_t ch) const noexcept;
         TGUI_NODISCARD inline bool ends_with(char32_t ch) const noexcept;
 
-        TGUI_NODISCARD std::size_t count(const char ch, const std::size_t pos = npos) const noexcept;
-        TGUI_NODISCARD std::size_t count(const wchar_t ch, const std::size_t pos = npos) const noexcept;
-        TGUI_NODISCARD std::size_t count(const char16_t ch, const std::size_t pos = npos) const noexcept;
-        TGUI_NODISCARD std::size_t count(const char32_t ch, const std::size_t pos = npos) const noexcept;
+        TGUI_NODISCARD std::size_t count(const char ch, const std::size_t pos = 0) const noexcept;
+        TGUI_NODISCARD std::size_t count(const wchar_t ch, const std::size_t pos = 0) const noexcept;
+        TGUI_NODISCARD std::size_t count(const char16_t ch, const std::size_t pos = 0) const noexcept;
+        TGUI_NODISCARD std::size_t count(const char32_t ch, const std::size_t pos = 0) const noexcept;
 
         inline friend bool operator==(const String& left, StringView right);
         inline friend bool operator==(const String& left, const char32_t* right);

--- a/include/TGUI/Widgets/TextArea.hpp
+++ b/include/TGUI/Widgets/TextArea.hpp
@@ -473,7 +473,7 @@ TGUI_MODULE_EXPORT namespace tgui
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Rearrange the text inside the text area (by using word wrap).
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        void rearrangeText(bool keepSelection);
+        void rearrangeText(bool keepSelection, const bool emitCaretChangedPosition = true);
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Updates the physical size of the scrollbars, as well as the viewport size.
@@ -630,10 +630,18 @@ TGUI_MODULE_EXPORT namespace tgui
 
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        // Updates m_selEnd with a new value and emits the onCaretPositionChange signal
+        // @param newValue the value to assign to m_selEnd.
+        /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        void updateSelEnd(const Vector2<std::size_t>& newValue);
+
+
+        /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     public:
 
-        SignalString onTextChange = {"TextChanged"};     //!< The text was changed. Optional parameter: new text
-        Signal onSelectionChange = {"SelectionChanged"}; //!< Selected text changed
+        SignalString onTextChange = {"TextChanged"};             //!< The text was changed. Optional parameter: new text
+        Signal onSelectionChange = {"SelectionChanged"};         //!< Selected text changed
+        Signal onCaretPositionChange = {"CaretPositionChanged"}; //!< Caret position changed
 
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -658,6 +666,9 @@ TGUI_MODULE_EXPORT namespace tgui
         Vector2<std::size_t> m_selStart;
         Vector2<std::size_t> m_selEnd;
         std::pair<Vector2<std::size_t>, Vector2<std::size_t>> m_lastSelection;
+        // If true, m_selEnd will not be changed in setCaretPosition().
+        // Used internally when setSelectedText() is called.
+        bool m_retainSelEnd = false;
 
         // Information about the caret
         Vector2f m_caretPosition;

--- a/include/TGUI/Widgets/TextArea.hpp
+++ b/include/TGUI/Widgets/TextArea.hpp
@@ -240,6 +240,30 @@ TGUI_MODULE_EXPORT namespace tgui
 
 
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        /// @brief Returns which line the blinking cursor is currently located on
+        ///
+        /// @return The line the caret is currently located on
+        ///
+        /// This function will take word-wrap into account. So, if a caret is on a line that is
+        /// currently wrapping, the caret will still register as being on the same line even if
+        /// that line spans many lines in the TextArea.
+        /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        TGUI_NODISCARD std::size_t getCaretLine() const;
+        
+        
+        /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        /// @brief Returns which column the blinking cursor is currently located on
+        ///
+        /// @return Characters before the caret on the caret's current line
+        ///
+        /// This function will take word-wrap into account. So, if a caret is on a line that is
+        /// currently wrapping, the caret will still register as being on the same line even if
+        /// that line spans many lines in the TextArea.
+        /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        TGUI_NODISCARD std::size_t getCaretColumn() const;
+
+
+        /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         /// @brief Makes the text area read-only or make it writable again
         ///
         /// @param readOnly  Should the text area be read-only?

--- a/src/String.cpp
+++ b/src/String.cpp
@@ -2283,6 +2283,31 @@ namespace tgui
 
     /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+    std::size_t String::count(char ch, std::size_t pos) const noexcept
+    {
+        return count(static_cast<char32_t>(ch), pos);
+    }
+
+    std::size_t String::count(wchar_t ch, std::size_t pos) const noexcept
+    {
+        return count(static_cast<char32_t>(ch), pos);
+    }
+
+    std::size_t String::count(char16_t ch, std::size_t pos) const noexcept
+    {
+        return count(static_cast<char32_t>(ch), pos);
+    }
+
+    std::size_t String::count(char32_t ch, std::size_t pos) const noexcept
+    {
+        std::size_t counter = 0;
+        for (std::size_t c = 0, end = std::min(m_string.size(), pos + 1); c < end; ++c)
+            if (m_string[c] == ch) ++counter;
+        return counter;
+    }
+
+    /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
     std::basic_ostream<char>& operator<<(std::basic_ostream<char>& os, const String& str)
     {
         os << std::string(str);

--- a/src/String.cpp
+++ b/src/String.cpp
@@ -2301,7 +2301,8 @@ namespace tgui
     std::size_t String::count(char32_t ch, std::size_t pos) const noexcept
     {
         std::size_t counter = 0;
-        for (std::size_t c = 0, end = std::min(m_string.size(), pos + 1); c < end; ++c)
+        const std::size_t end = m_string.size();
+        for (std::size_t c = pos; c < end; ++c)
             if (m_string[c] == ch) ++counter;
         return counter;
     }

--- a/src/Widgets/TextArea.cpp
+++ b/src/Widgets/TextArea.cpp
@@ -358,6 +358,31 @@ namespace tgui
 
     /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+    std::size_t TextArea::getCaretLine() const
+    {
+        const auto caret = getCaretPosition();
+        if (caret == 0)
+            return 1;
+        else
+            return m_text.count('\n', caret - 1) + 1;
+    }
+
+    /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    
+    std::size_t TextArea::getCaretColumn() const
+    {
+        const auto caret = getCaretPosition();
+        if (caret == 0)
+            return 1;
+        auto lineStart = m_text.rfind('\n', caret - 1);
+        if (lineStart == String::npos)
+            return caret + 1;
+        else
+            return caret - lineStart;
+    }
+
+    /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    
     void TextArea::setReadOnly(bool readOnly)
     {
         m_readOnly = readOnly;

--- a/src/Widgets/TextArea.cpp
+++ b/src/Widgets/TextArea.cpp
@@ -365,7 +365,7 @@ namespace tgui
         if (caret == 0)
             return 1;
         else
-            return m_text.count('\n', caret - 1) + 1;
+            return m_text.substr(0, caret).count('\n') + 1;
     }
 
     /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/tests/String.cpp
+++ b/tests/String.cpp
@@ -1550,6 +1550,26 @@ TEST_CASE("[String]")
         REQUIRE(tgui::viewEndsWith(U"abc\u20ACxyz", U"xyz"));
     }
 
+    SECTION("count")
+    {
+        REQUIRE(tgui::String(U"abc\u20ACxyz").count('a') == 1);
+        REQUIRE(tgui::String(U"abc\u20ACxyz").count(L'a') == 1);
+        REQUIRE(tgui::String(U"abc\u20ACxyz").count(u'a') == 1);
+        REQUIRE(tgui::String(U"abc\u20ACxyz").count(U'a') == 1);
+
+        REQUIRE(tgui::String(U"\n\n\n\n\n").count(U'\n') == 5);
+        REQUIRE(tgui::String(U"a\nb\nc\u20AC\nx\ny\nz").count(U'\n') == 5);
+        REQUIRE(tgui::String(U"").count(U'\n') == 0);
+        REQUIRE(tgui::String(U"\n").count(U'\n') == 1);
+        REQUIRE(tgui::String(U"abc\u20ACxyz").count(U'\u20AC') == 1);
+
+        REQUIRE(tgui::String(U"a\nb\nc\u20AC\nx\ny\nz").count(U'\n', 1) == 5);
+        REQUIRE(tgui::String(U"a\nb\nc\u20AC\nx\ny\nz").count(U'\n', 6) == 3);
+        REQUIRE(tgui::String(U"a\nb\nc\u20AC\nx\ny\nz").count(U'a', 0) == 1);
+        REQUIRE(tgui::String(U"a\nb\nc\u20AC\nx\ny\nz").count(U'a', 1) == 0);
+        REQUIRE(tgui::String(U"a\nb\nc\u20AC\nx\ny\nz").count(U'a', 40) == 0);
+    }
+
     SECTION("isWhitespace")
     {
         REQUIRE(tgui::isWhitespace(' '));


### PR DESCRIPTION
# Changes to Public Interfaces

- Add `count(char, size_t)` methods to `String`. These methods count the number of occurrences of a given character within the string.
- Add `getCaretLine()` and `getCaretColumn()` to `TextArea`.
- Add `onCaretPositionChange` signal to `TextArea`.

# Testing

Most of the tests I performed can be seen below. In all cases, `getText()` returned the correct/updated text when invoked within the `onCaretPositionChange` signal handler. "Location" or "position" refers to the current caret position unless otherwise stated.

| Test Case | Actions | Result |
| --- | --- | --- |
| `setSelectedText()` | Select portion of the text. | Emitted once. |
| `setSelectedText()` | Select portion of the text that ends at the current caret position. | Emitted once, despite caret not changing position. This case probably doesn't matter. |
| `setSelectedText()` | Select the same portion of the text. | Not emitted. |
| `setCaretPosition()` | Set to a different location. | Emitted once. |
| `setCaretPosition()` | Set to the same location. | Not emitted. |
| `leftMousePressed()` | Single click at different location. | Emitted once. |
| `leftMousePressed()` | Single click at same location. | Not emitted. |
| `leftMousePressed()` | Clicking on scrollbars. | Not emitted. |
| `leftMousePressed()` | Double click. | Emitted once for each click, unless the caret position does not change on a click. |
| `mouseMoved()` | No mouse button held. | Not emitted. |
| `mouseMoved()` | Mouse button held. | Emitted once for every change of the caret position. |
| `keyPressed()` | Left, Right, Up, Down, End, Home, End + Ctrl, Home + Ctrl. | Emitted once per key press, but only when caret position changes. |
| `keyPressed()` (`moveCaretWordBegin()`, `moveCaretWordEnd()`, `moveCaretPageUp()`, `moveCaretPageDown()`) | Page Up, Page Down, Left + Ctrl, Right + Ctrl. | Emitted once per key press, but only when caret position changes. |
| `textEntered()` | Vertical scrollbar is Automatic or Always. Enter key. | Emits one signal per key press. |
| `textEntered()` | Vertical scrollbar is Automatic or Always. Any other key. | Emits one signal per key press. |
| `textEntered()` | Vertical scrollbar is Never. Enter key, and it can fit. | Emits one signal per key press. |
| `textEntered()` | Vertical scrollbar is Never. Enter key, and it can't fit. | Not emitted. |
| `textEntered()` | Vertical scrollbar is Never. Any other key, and it can fit. | Emits one signal per key press. |
| `textEntered()` | Vertical scrollbar is Never. Any other key, and it can't fit. | Not emitted. |
| `deleteSelectedCharacters()` | End Sel > Start Sel | Since End Sel is reset to Start Sel, emits one signal. |
| `deleteSelectedCharacters()` | End Sel <= Start Sel | Since End Sel is not changed, no signal is emitted. |
| `backspaceKeyPressed()` | At start of text. | Not emitted. |
| `backspaceKeyPressed()` | At any other location, no text selected. | Emitted once. |
| `backspaceKeyPressed()` | At beginning of line that was added due to word wrap. | Emitted once. |
| `pasteTextFromClipboard()` | Pasting empty string. | Not emitted. |
| `pasteTextFromClipboard()` | Pasting string with no text selected, regardless of location. | Emitted once. |
| `pasteTextFromClipboard()` | Pasting string with text selected, caret at start of selection. | Emitted once. |
| `pasteTextFromClipboard()` | Pasting string with text selected, caret at end of selection. | Emitted twice, once after deleting the selected characters, once after pasting string. |
| `selectAllText()` | Positioned at end of text. | Not emitted. |
| `selectAllText()` | Positioned anywhere else. | Emitted once. |