### PR TITLE
Widgets with dots in their names can now be fully referenced in layout expressions

### DIFF
--- a/include/TGUI/Backend/Window/BackendGui.hpp
+++ b/include/TGUI/Backend/Window/BackendGui.hpp
@@ -229,7 +229,10 @@ TGUI_MODULE_EXPORT namespace tgui
         /// @param widgetPtr   Pointer to the widget you would like to add
         /// @param widgetName  If you want to access the widget later then you must do this with this name
         ///
-        /// @warning The widget name should not contain whitespace
+        /// @warning Widgets should be named as if they are C++ variables, i.e. names must not include any whitespace, or most
+        ///          symbols (e.g.: +, -, *, /, ., &), and should not start with a number. If you do not follow these rules,
+        ///          layout expressions may give unexpected results. Alphanumeric characters and underscores are safe to use,
+        ///          and widgets are permitted to have no name.
         ///
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         void add(const Widget::Ptr& widgetPtr, const String& widgetName = "");

--- a/include/TGUI/Container.hpp
+++ b/include/TGUI/Container.hpp
@@ -133,7 +133,10 @@ TGUI_MODULE_EXPORT namespace tgui
         /// @param widgetPtr   Pointer to the widget you would like to add
         /// @param widgetName  You can give the widget a unique name to retrieve it from the container later
         ///
-        /// @warning The widget name should not contain whitespace
+        /// @warning Widgets should be named as if they are C++ variables, i.e. names must not include any whitespace, or most
+        ///          symbols (e.g.: +, -, *, /, ., &), and should not start with a number. If you do not follow these rules,
+        ///          layout expressions may give unexpected results. Alphanumeric characters and underscores are safe to use,
+        ///          and widgets are permitted to have no name.
         ///
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         virtual void add(const Widget::Ptr& widgetPtr, const String& widgetName = "");

--- a/include/TGUI/Widget.hpp
+++ b/include/TGUI/Widget.hpp
@@ -784,6 +784,11 @@ TGUI_MODULE_EXPORT namespace tgui
         /// @param name  New name for the widget
         ///
         /// @warning This name is overwritten when adding the widget to its parent. You should only set it afterwards.
+        ///
+        /// @warning Widgets should be named as if they are C++ variables, i.e. names must not include any whitespace, or most
+        ///          symbols (e.g.: +, -, *, /, ., &), and should not start with a number. If you do not follow these rules,
+        ///          layout expressions may give unexpected results. Alphanumeric characters and underscores are safe to use,
+        ///          and widgets are permitted to have no name.
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         void setWidgetName(const String& name);
 

--- a/include/TGUI/Widgets/BoxLayout.hpp
+++ b/include/TGUI/Widgets/BoxLayout.hpp
@@ -86,6 +86,11 @@ TGUI_MODULE_EXPORT namespace tgui
         /// @param widget      Pointer to the widget you would like to add
         /// @param widgetName  An identifier to access to the widget later
         ///
+        /// @warning Widgets should be named as if they are C++ variables, i.e. names must not include any whitespace, or most
+        ///          symbols (e.g.: +, -, *, /, ., &), and should not start with a number. If you do not follow these rules,
+        ///          layout expressions may give unexpected results. Alphanumeric characters and underscores are safe to use,
+        ///          and widgets are permitted to have no name.
+        ///
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         void add(const Widget::Ptr& widget, const String& widgetName = "") override;
 
@@ -98,6 +103,11 @@ TGUI_MODULE_EXPORT namespace tgui
         /// @param widgetName  An identifier to access to the widget later
         ///
         /// If the index is too high, the widget will simply be added at the end of the list.
+        ///
+        /// @warning Widgets should be named as if they are C++ variables, i.e. names must not include any whitespace, or most
+        ///          symbols (e.g.: +, -, *, /, ., &), and should not start with a number. If you do not follow these rules,
+        ///          layout expressions may give unexpected results. Alphanumeric characters and underscores are safe to use,
+        ///          and widgets are permitted to have no name.
         ///
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         virtual void insert(std::size_t index, const Widget::Ptr& widget, const String& widgetName = "");

--- a/include/TGUI/Widgets/BoxLayoutRatios.hpp
+++ b/include/TGUI/Widgets/BoxLayoutRatios.hpp
@@ -61,6 +61,11 @@ TGUI_MODULE_EXPORT namespace tgui
         /// @param widgetName  An identifier to access to the widget later
         ///
         /// The widget will have a ratio of 1.
+        ///
+        /// @warning Widgets should be named as if they are C++ variables, i.e. names must not include any whitespace, or most
+        ///          symbols (e.g.: +, -, *, /, ., &), and should not start with a number. If you do not follow these rules,
+        ///          layout expressions may give unexpected results. Alphanumeric characters and underscores are safe to use,
+        ///          and widgets are permitted to have no name.
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         void add(const Widget::Ptr& widget, const String& widgetName = "") override;
 
@@ -71,6 +76,11 @@ TGUI_MODULE_EXPORT namespace tgui
         /// @param widget      Pointer to the widget you would like to add
         /// @param ratio       Ratio to determine the size compared to other widgets
         /// @param widgetName  An identifier to access to the widget later
+        ///
+        /// @warning Widgets should be named as if they are C++ variables, i.e. names must not include any whitespace, or most
+        ///          symbols (e.g.: +, -, *, /, ., &), and should not start with a number. If you do not follow these rules,
+        ///          layout expressions may give unexpected results. Alphanumeric characters and underscores are safe to use,
+        ///          and widgets are permitted to have no name.
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         void add(const Widget::Ptr& widget, float ratio, const String& widgetName = "");
 
@@ -85,6 +95,11 @@ TGUI_MODULE_EXPORT namespace tgui
         /// The widget will have a ratio of 1.
         ///
         /// If the index is too high, the widget will simply be added at the end of the list.
+        ///
+        /// @warning Widgets should be named as if they are C++ variables, i.e. names must not include any whitespace, or most
+        ///          symbols (e.g.: +, -, *, /, ., &), and should not start with a number. If you do not follow these rules,
+        ///          layout expressions may give unexpected results. Alphanumeric characters and underscores are safe to use,
+        ///          and widgets are permitted to have no name.
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         void insert(std::size_t index, const Widget::Ptr& widget, const String& widgetName = "") override;
 
@@ -101,6 +116,11 @@ TGUI_MODULE_EXPORT namespace tgui
         /// the first widget will be twice as large as the second one.
         ///
         /// If the index is too high, the widget will simply be added at the end of the list.
+        ///
+        /// @warning Widgets should be named as if they are C++ variables, i.e. names must not include any whitespace, or most
+        ///          symbols (e.g.: +, -, *, /, ., &), and should not start with a number. If you do not follow these rules,
+        ///          layout expressions may give unexpected results. Alphanumeric characters and underscores are safe to use,
+        ///          and widgets are permitted to have no name.
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         void insert(std::size_t index, const Widget::Ptr& widget, float ratio, const String& widgetName = "");
 

--- a/include/TGUI/Widgets/ScrollablePanel.hpp
+++ b/include/TGUI/Widgets/ScrollablePanel.hpp
@@ -152,6 +152,11 @@ TGUI_MODULE_EXPORT namespace tgui
         ///
         /// @param widget      Pointer to the widget you would like to add
         /// @param widgetName  An identifier to access to the widget later
+        ///
+        /// @warning Widgets should be named as if they are C++ variables, i.e. names must not include any whitespace, or most
+        ///          symbols (e.g.: +, -, *, /, ., &), and should not start with a number. If you do not follow these rules,
+        ///          layout expressions may give unexpected results. Alphanumeric characters and underscores are safe to use,
+        ///          and widgets are permitted to have no name.
         /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         void add(const Widget::Ptr& widget, const String& widgetName = "") override;
 


### PR DESCRIPTION
Previously, it was impossible to reference a widget's X, Y, width, etc. properties in a layout expression if that widget had dots in its name.

Finding the last dot instead of the first one resolves this issue.

There might well be edge cases (such as if there is a widget called `Widget.x`) but dealing with these is not worth it, and the user shouldn't be naming widgets in such a way if they need to access these properties reliably.