### PR TITLE
Ignore the .qtcreator directory - there's nothing relevant there

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ CmakeSettings.json
 CombinedSources*.cpp
 .DS_Store
 *~
+.qtcreator/


### PR DESCRIPTION
Since I use qtcreator for my daily work (which includes tgui) I get a folder (".qtcreator") created in the project directory and I can't help that. But since there's nothing TGUI related in that folder and it's just annoying when doing 'git status' and the like, add it to the .gitignore file (I don't see how this could be a problem for any other users of TGUI, so here's a commit to just ignore it).