### PR TITLE
Avoid std::endl in examples

### DIFF
--- a/examples/many_different_widgets/ManyDifferentWidgets.cpp
+++ b/examples/many_different_widgets/ManyDifferentWidgets.cpp
@@ -237,7 +237,7 @@ bool runExample(tgui::BackendGui& gui)
     }
     catch (const tgui::Exception& e)
     {
-        std::cerr << "TGUI Exception: " << e.what() << std::endl;
+        std::cerr << "TGUI Exception: " << e.what() << '\n';
         return false;
     }
 

--- a/examples/scalable_login_screen/ScalableLoginScreen.cpp
+++ b/examples/scalable_login_screen/ScalableLoginScreen.cpp
@@ -32,8 +32,8 @@
 
 void login(const tgui::EditBox::Ptr& username, const tgui::EditBox::Ptr& password)
 {
-    std::cout << "Username: " << username->getText() << std::endl;
-    std::cout << "Password: " << password->getText() << std::endl;
+    std::cout << "Username: " << username->getText() << '\n';
+    std::cout << "Password: " << password->getText() << '\n';
 }
 
 void updateTextSize(tgui::BackendGui& gui)
@@ -95,7 +95,7 @@ bool runExample(tgui::BackendGui& gui)
     }
     catch (const tgui::Exception& e)
     {
-        std::cerr << "Failed to load TGUI widgets: " << e.what() << std::endl;
+        std::cerr << "Failed to load TGUI widgets: " << e.what() << '\n';
         return false;
     }
 }


### PR DESCRIPTION
'\n' ends a line. std::endl does an additional std::flush that we don't need.