### PR TITLE
Update copyright year to 2026

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 ####################################################################################################
 # TGUI - Texus' Graphical User Interface
-# Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+# Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 #
 # This software is provided 'as-is', without any express or implied warranty.
 # In no event will the authors be held liable for any damages arising from the use of this software.

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1,6 +1,6 @@
 ####################################################################################################
 # TGUI - Texus' Graphical User Interface
-# Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+# Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 #
 # This software is provided 'as-is', without any express or implied warranty.
 # In no event will the authors be held liable for any damages arising from the use of this software.

--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -1,6 +1,6 @@
 ####################################################################################################
 # TGUI - Texus' Graphical User Interface
-# Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+# Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 #
 # This software is provided 'as-is', without any express or implied warranty.
 # In no event will the authors be held liable for any damages arising from the use of this software.

--- a/cmake/Modules/FindSDL2.cmake
+++ b/cmake/Modules/FindSDL2.cmake
@@ -1,7 +1,7 @@
 # Distributed under the OSI-approved BSD 3-Clause License.
 # See https://cmake.org/licensing for details.
 
-#  Copyright 2021-2025 Bruno Van de Velde <vdv_b@tgui.eu>
+#  Copyright 2021-2026 Bruno Van de Velde <vdv_b@tgui.eu>
 #  Copyright 2019 Amine Ben Hassouna <amine.benhassouna@gmail.com>
 #  Copyright 2000-2019 Kitware, Inc. and Contributors
 #  All rights reserved.

--- a/cmake/Modules/Findglfw3.cmake
+++ b/cmake/Modules/Findglfw3.cmake
@@ -1,6 +1,6 @@
 ####################################################################################################
 # TGUI - Texus' Graphical User Interface
-# Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+# Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 #
 # This software is provided 'as-is', without any express or implied warranty.
 # In no event will the authors be held liable for any damages arising from the use of this software.

--- a/cmake/Modules/Findraylib.cmake
+++ b/cmake/Modules/Findraylib.cmake
@@ -1,6 +1,6 @@
 ####################################################################################################
 # TGUI - Texus' Graphical User Interface
-# Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+# Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 #
 # This software is provided 'as-is', without any express or implied warranty.
 # In no event will the authors be held liable for any damages arising from the use of this software.

--- a/cmake/TGUIConfig.cmake.in
+++ b/cmake/TGUIConfig.cmake.in
@@ -1,6 +1,6 @@
 ####################################################################################################
 # TGUI - Texus' Graphical User Interface
-# Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+# Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 #
 # This software is provided 'as-is', without any express or implied warranty.
 # In no event will the authors be held liable for any damages arising from the use of this software.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,6 @@
 ####################################################################################################
 # TGUI - Texus' Graphical User Interface
-# Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+# Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 #
 # This software is provided 'as-is', without any express or implied warranty.
 # In no event will the authors be held liable for any damages arising from the use of this software.

--- a/examples/android/RAYLIB/app/src/main/cpp/main.cpp
+++ b/examples/android/RAYLIB/app/src/main/cpp/main.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/examples/android/SDL_GPU/app/jni/example.cpp
+++ b/examples/android/SDL_GPU/app/jni/example.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/examples/android/SDL_RENDERER/app/jni/src/example.cpp
+++ b/examples/android/SDL_RENDERER/app/jni/src/example.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/examples/android/SDL_TTF_GLES2/app/jni/src/example.cpp
+++ b/examples/android/SDL_TTF_GLES2/app/jni/src/example.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/examples/android/SFML_GRAPHICS/app/src/main/jni/main-sfml2.cpp
+++ b/examples/android/SFML_GRAPHICS/app/src/main/jni/main-sfml2.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/examples/android/SFML_GRAPHICS/app/src/main/jni/main-sfml3.cpp
+++ b/examples/android/SFML_GRAPHICS/app/src/main/jni/main-sfml3.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/examples/iOS/iOS-example-SDL_RENDERER.cpp
+++ b/examples/iOS/iOS-example-SDL_RENDERER.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/examples/iOS/iOS-example-SFML_GRAPHICS.cpp
+++ b/examples/iOS/iOS-example-SFML_GRAPHICS.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/examples/main-GLFW_GLES2.cpp
+++ b/examples/main-GLFW_GLES2.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/examples/main-GLFW_OPENGL3.cpp
+++ b/examples/main-GLFW_OPENGL3.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/examples/main-RAYLIB.cpp
+++ b/examples/main-RAYLIB.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/examples/main-SDL_GLES2.cpp
+++ b/examples/main-SDL_GLES2.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/examples/main-SDL_GPU.cpp
+++ b/examples/main-SDL_GPU.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/examples/main-SDL_OPENGL3.cpp
+++ b/examples/main-SDL_OPENGL3.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/examples/main-SDL_RENDERER.cpp
+++ b/examples/main-SDL_RENDERER.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/examples/main-SDL_TTF_GLES2.cpp
+++ b/examples/main-SDL_TTF_GLES2.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/examples/main-SDL_TTF_OPENGL3.cpp
+++ b/examples/main-SDL_TTF_OPENGL3.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/examples/main-SFML_GRAPHICS.cpp
+++ b/examples/main-SFML_GRAPHICS.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/examples/main-SFML_OPENGL3.cpp
+++ b/examples/main-SFML_OPENGL3.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/examples/many_different_widgets/ManyDifferentWidgets.cpp
+++ b/examples/many_different_widgets/ManyDifferentWidgets.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/examples/scalable_login_screen/ScalableLoginScreen.cpp
+++ b/examples/scalable_login_screen/ScalableLoginScreen.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/CMakeLists.txt
+++ b/gui-builder/CMakeLists.txt
@@ -1,6 +1,6 @@
 ####################################################################################################
 # TGUI - Texus' Graphical User Interface
-# Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+# Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 #
 # This software is provided 'as-is', without any express or implied warranty.
 # In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/include/Form.hpp
+++ b/gui-builder/include/Form.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/include/GuiBuilder.hpp
+++ b/gui-builder/include/GuiBuilder.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/include/WidgetInfo.hpp
+++ b/gui-builder/include/WidgetInfo.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/include/WidgetProperties/BitmapButtonProperties.hpp
+++ b/gui-builder/include/WidgetProperties/BitmapButtonProperties.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/include/WidgetProperties/ButtonProperties.hpp
+++ b/gui-builder/include/WidgetProperties/ButtonProperties.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/include/WidgetProperties/ChatBoxProperties.hpp
+++ b/gui-builder/include/WidgetProperties/ChatBoxProperties.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/include/WidgetProperties/CheckBoxProperties.hpp
+++ b/gui-builder/include/WidgetProperties/CheckBoxProperties.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/include/WidgetProperties/ChildWindowProperties.hpp
+++ b/gui-builder/include/WidgetProperties/ChildWindowProperties.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/include/WidgetProperties/ClickableWidgetProperties.hpp
+++ b/gui-builder/include/WidgetProperties/ClickableWidgetProperties.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/include/WidgetProperties/ComboBoxProperties.hpp
+++ b/gui-builder/include/WidgetProperties/ComboBoxProperties.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/include/WidgetProperties/EditBoxProperties.hpp
+++ b/gui-builder/include/WidgetProperties/EditBoxProperties.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/include/WidgetProperties/EditBoxSliderProperties.hpp
+++ b/gui-builder/include/WidgetProperties/EditBoxSliderProperties.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/include/WidgetProperties/GroupProperties.hpp
+++ b/gui-builder/include/WidgetProperties/GroupProperties.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/include/WidgetProperties/GrowHorizontalLayoutProperties.hpp
+++ b/gui-builder/include/WidgetProperties/GrowHorizontalLayoutProperties.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/include/WidgetProperties/GrowVerticalLayoutProperties.hpp
+++ b/gui-builder/include/WidgetProperties/GrowVerticalLayoutProperties.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/include/WidgetProperties/HorizontalLayoutProperties.hpp
+++ b/gui-builder/include/WidgetProperties/HorizontalLayoutProperties.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/include/WidgetProperties/HorizontalWrapProperties.hpp
+++ b/gui-builder/include/WidgetProperties/HorizontalWrapProperties.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/include/WidgetProperties/KnobProperties.hpp
+++ b/gui-builder/include/WidgetProperties/KnobProperties.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/include/WidgetProperties/LabelProperties.hpp
+++ b/gui-builder/include/WidgetProperties/LabelProperties.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/include/WidgetProperties/ListBoxProperties.hpp
+++ b/gui-builder/include/WidgetProperties/ListBoxProperties.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/include/WidgetProperties/ListViewProperties.hpp
+++ b/gui-builder/include/WidgetProperties/ListViewProperties.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/include/WidgetProperties/MenuBarProperties.hpp
+++ b/gui-builder/include/WidgetProperties/MenuBarProperties.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/include/WidgetProperties/PanelListBoxProperties.hpp
+++ b/gui-builder/include/WidgetProperties/PanelListBoxProperties.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/include/WidgetProperties/PanelProperties.hpp
+++ b/gui-builder/include/WidgetProperties/PanelProperties.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/include/WidgetProperties/PictureProperties.hpp
+++ b/gui-builder/include/WidgetProperties/PictureProperties.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/include/WidgetProperties/ProgressBarProperties.hpp
+++ b/gui-builder/include/WidgetProperties/ProgressBarProperties.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/include/WidgetProperties/RadioButtonProperties.hpp
+++ b/gui-builder/include/WidgetProperties/RadioButtonProperties.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/include/WidgetProperties/RangeSliderProperties.hpp
+++ b/gui-builder/include/WidgetProperties/RangeSliderProperties.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/include/WidgetProperties/RichTextLabelProperties.hpp
+++ b/gui-builder/include/WidgetProperties/RichTextLabelProperties.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/include/WidgetProperties/ScrollablePanelProperties.hpp
+++ b/gui-builder/include/WidgetProperties/ScrollablePanelProperties.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/include/WidgetProperties/ScrollbarProperties.hpp
+++ b/gui-builder/include/WidgetProperties/ScrollbarProperties.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/include/WidgetProperties/SeparatorLineProperties.hpp
+++ b/gui-builder/include/WidgetProperties/SeparatorLineProperties.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/include/WidgetProperties/SliderProperties.hpp
+++ b/gui-builder/include/WidgetProperties/SliderProperties.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/include/WidgetProperties/SpinButtonProperties.hpp
+++ b/gui-builder/include/WidgetProperties/SpinButtonProperties.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/include/WidgetProperties/SpinControlProperties.hpp
+++ b/gui-builder/include/WidgetProperties/SpinControlProperties.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/include/WidgetProperties/SplitContainerProperties.hpp
+++ b/gui-builder/include/WidgetProperties/SplitContainerProperties.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/include/WidgetProperties/TabsProperties.hpp
+++ b/gui-builder/include/WidgetProperties/TabsProperties.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/include/WidgetProperties/TextAreaProperties.hpp
+++ b/gui-builder/include/WidgetProperties/TextAreaProperties.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/include/WidgetProperties/ToggleButtonProperties.hpp
+++ b/gui-builder/include/WidgetProperties/ToggleButtonProperties.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/include/WidgetProperties/TreeViewProperties.hpp
+++ b/gui-builder/include/WidgetProperties/TreeViewProperties.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/include/WidgetProperties/VerticalLayoutProperties.hpp
+++ b/gui-builder/include/WidgetProperties/VerticalLayoutProperties.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/include/WidgetProperties/WidgetProperties.hpp
+++ b/gui-builder/include/WidgetProperties/WidgetProperties.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/src/Form.cpp
+++ b/gui-builder/src/Form.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/src/GuiBuilder.cpp
+++ b/gui-builder/src/GuiBuilder.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/gui-builder/src/main.cpp
+++ b/gui-builder/src/main.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/AbsoluteOrRelativeValue.hpp
+++ b/include/TGUI/AbsoluteOrRelativeValue.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/AllWidgets.hpp
+++ b/include/TGUI/AllWidgets.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Animation.hpp
+++ b/include/TGUI/Animation.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Any.hpp
+++ b/include/TGUI/Any.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Font/BackendFont.hpp
+++ b/include/TGUI/Backend/Font/BackendFont.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Font/BackendFontFactory.hpp
+++ b/include/TGUI/Backend/Font/BackendFontFactory.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Font/FreeType/BackendFontFreeType.hpp
+++ b/include/TGUI/Backend/Font/FreeType/BackendFontFreeType.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Font/Raylib/BackendFontRaylib.hpp
+++ b/include/TGUI/Backend/Font/Raylib/BackendFontRaylib.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Font/SDL_ttf/BackendFontSDLttf.hpp
+++ b/include/TGUI/Backend/Font/SDL_ttf/BackendFontSDLttf.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Font/SFML-Graphics/BackendFontSFML.hpp
+++ b/include/TGUI/Backend/Font/SFML-Graphics/BackendFontSFML.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/GLFW-GLES2.hpp
+++ b/include/TGUI/Backend/GLFW-GLES2.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/GLFW-OpenGL3.hpp
+++ b/include/TGUI/Backend/GLFW-OpenGL3.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Renderer/BackendRenderTarget.hpp
+++ b/include/TGUI/Backend/Renderer/BackendRenderTarget.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Renderer/BackendRenderer.hpp
+++ b/include/TGUI/Backend/Renderer/BackendRenderer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Renderer/BackendText.hpp
+++ b/include/TGUI/Backend/Renderer/BackendText.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Renderer/BackendTexture.hpp
+++ b/include/TGUI/Backend/Renderer/BackendTexture.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Renderer/GLES2/BackendRenderTargetGLES2.hpp
+++ b/include/TGUI/Backend/Renderer/GLES2/BackendRenderTargetGLES2.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Renderer/GLES2/BackendRendererGLES2.hpp
+++ b/include/TGUI/Backend/Renderer/GLES2/BackendRendererGLES2.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Renderer/GLES2/BackendTextureGLES2.hpp
+++ b/include/TGUI/Backend/Renderer/GLES2/BackendTextureGLES2.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Renderer/GLES2/CanvasGLES2.hpp
+++ b/include/TGUI/Backend/Renderer/GLES2/CanvasGLES2.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Renderer/OpenGL.hpp
+++ b/include/TGUI/Backend/Renderer/OpenGL.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Renderer/OpenGL3/BackendRenderTargetOpenGL3.hpp
+++ b/include/TGUI/Backend/Renderer/OpenGL3/BackendRenderTargetOpenGL3.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Renderer/OpenGL3/BackendRendererOpenGL3.hpp
+++ b/include/TGUI/Backend/Renderer/OpenGL3/BackendRendererOpenGL3.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Renderer/OpenGL3/BackendTextureOpenGL3.hpp
+++ b/include/TGUI/Backend/Renderer/OpenGL3/BackendTextureOpenGL3.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Renderer/OpenGL3/CanvasOpenGL3.hpp
+++ b/include/TGUI/Backend/Renderer/OpenGL3/CanvasOpenGL3.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Renderer/Raylib/BackendRenderTargetRaylib.hpp
+++ b/include/TGUI/Backend/Renderer/Raylib/BackendRenderTargetRaylib.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Renderer/Raylib/BackendRendererRaylib.hpp
+++ b/include/TGUI/Backend/Renderer/Raylib/BackendRendererRaylib.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Renderer/Raylib/BackendTextureRaylib.hpp
+++ b/include/TGUI/Backend/Renderer/Raylib/BackendTextureRaylib.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Renderer/Raylib/CanvasRaylib.hpp
+++ b/include/TGUI/Backend/Renderer/Raylib/CanvasRaylib.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Renderer/SDL_GPU/BackendRenderTargetSDLGPU.hpp
+++ b/include/TGUI/Backend/Renderer/SDL_GPU/BackendRenderTargetSDLGPU.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Renderer/SDL_GPU/BackendRendererSDLGPU.hpp
+++ b/include/TGUI/Backend/Renderer/SDL_GPU/BackendRendererSDLGPU.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Renderer/SDL_GPU/BackendTextureSDLGPU.hpp
+++ b/include/TGUI/Backend/Renderer/SDL_GPU/BackendTextureSDLGPU.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Renderer/SDL_GPU/CanvasSDLGPU.hpp
+++ b/include/TGUI/Backend/Renderer/SDL_GPU/CanvasSDLGPU.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Renderer/SDL_Renderer/BackendRenderTargetSDL.hpp
+++ b/include/TGUI/Backend/Renderer/SDL_Renderer/BackendRenderTargetSDL.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Renderer/SDL_Renderer/BackendRendererSDL.hpp
+++ b/include/TGUI/Backend/Renderer/SDL_Renderer/BackendRendererSDL.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Renderer/SDL_Renderer/BackendTextureSDL.hpp
+++ b/include/TGUI/Backend/Renderer/SDL_Renderer/BackendTextureSDL.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Renderer/SDL_Renderer/CanvasSDL.hpp
+++ b/include/TGUI/Backend/Renderer/SDL_Renderer/CanvasSDL.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Renderer/SFML-Graphics/BackendRenderTargetSFML.hpp
+++ b/include/TGUI/Backend/Renderer/SFML-Graphics/BackendRenderTargetSFML.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Renderer/SFML-Graphics/BackendRendererSFML.hpp
+++ b/include/TGUI/Backend/Renderer/SFML-Graphics/BackendRendererSFML.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Renderer/SFML-Graphics/BackendTextureSFML.hpp
+++ b/include/TGUI/Backend/Renderer/SFML-Graphics/BackendTextureSFML.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Renderer/SFML-Graphics/CanvasSFML.hpp
+++ b/include/TGUI/Backend/Renderer/SFML-Graphics/CanvasSFML.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/SDL-GLES2.hpp
+++ b/include/TGUI/Backend/SDL-GLES2.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/SDL-GPU.hpp
+++ b/include/TGUI/Backend/SDL-GPU.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/SDL-OpenGL3.hpp
+++ b/include/TGUI/Backend/SDL-OpenGL3.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/SDL-Renderer.hpp
+++ b/include/TGUI/Backend/SDL-Renderer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/SDL-TTF-GLES2.hpp
+++ b/include/TGUI/Backend/SDL-TTF-GLES2.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/SDL-TTF-OpenGL3.hpp
+++ b/include/TGUI/Backend/SDL-TTF-OpenGL3.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/SFML-Graphics.hpp
+++ b/include/TGUI/Backend/SFML-Graphics.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/SFML-OpenGL3.hpp
+++ b/include/TGUI/Backend/SFML-OpenGL3.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Window/Backend.hpp
+++ b/include/TGUI/Backend/Window/Backend.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Window/BackendGui.hpp
+++ b/include/TGUI/Backend/Window/BackendGui.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Window/GLFW/BackendGLFW.hpp
+++ b/include/TGUI/Backend/Window/GLFW/BackendGLFW.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Window/GLFW/BackendGuiGLFW.hpp
+++ b/include/TGUI/Backend/Window/GLFW/BackendGuiGLFW.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Window/Raylib/BackendGuiRaylib.hpp
+++ b/include/TGUI/Backend/Window/Raylib/BackendGuiRaylib.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Window/Raylib/BackendRaylib.hpp
+++ b/include/TGUI/Backend/Window/Raylib/BackendRaylib.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Window/SDL/BackendGuiSDL.hpp
+++ b/include/TGUI/Backend/Window/SDL/BackendGuiSDL.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Window/SDL/BackendSDL.hpp
+++ b/include/TGUI/Backend/Window/SDL/BackendSDL.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Window/SFML/BackendGuiSFML.hpp
+++ b/include/TGUI/Backend/Window/SFML/BackendGuiSFML.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/Window/SFML/BackendSFML.hpp
+++ b/include/TGUI/Backend/Window/SFML/BackendSFML.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Backend/raylib.hpp
+++ b/include/TGUI/Backend/raylib.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Base64.hpp
+++ b/include/TGUI/Base64.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Color.hpp
+++ b/include/TGUI/Color.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Components.hpp
+++ b/include/TGUI/Components.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Config.hpp.in
+++ b/include/TGUI/Config.hpp.in
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Container.hpp
+++ b/include/TGUI/Container.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/CopiedPtr.hpp
+++ b/include/TGUI/CopiedPtr.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/CopiedSharedPtr.hpp
+++ b/include/TGUI/CopiedSharedPtr.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Core.hpp
+++ b/include/TGUI/Core.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Cursor.hpp
+++ b/include/TGUI/Cursor.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/CustomWidgetForBindings.hpp
+++ b/include/TGUI/CustomWidgetForBindings.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/DefaultBackendWindow.hpp
+++ b/include/TGUI/DefaultBackendWindow.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Duration.hpp
+++ b/include/TGUI/Duration.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Event.hpp
+++ b/include/TGUI/Event.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Exception.hpp
+++ b/include/TGUI/Exception.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/FileDialogIconLoader.hpp
+++ b/include/TGUI/FileDialogIconLoader.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Filesystem.hpp
+++ b/include/TGUI/Filesystem.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Font.hpp
+++ b/include/TGUI/Font.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Global.hpp
+++ b/include/TGUI/Global.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Keyboard.hpp
+++ b/include/TGUI/Keyboard.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Layout.hpp
+++ b/include/TGUI/Layout.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Loading/DataIO.hpp
+++ b/include/TGUI/Loading/DataIO.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Loading/Deserializer.hpp
+++ b/include/TGUI/Loading/Deserializer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Loading/ImageLoader.hpp
+++ b/include/TGUI/Loading/ImageLoader.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Loading/Serializer.hpp
+++ b/include/TGUI/Loading/Serializer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Loading/Theme.hpp
+++ b/include/TGUI/Loading/Theme.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Loading/ThemeLoader.hpp
+++ b/include/TGUI/Loading/ThemeLoader.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Loading/WidgetFactory.hpp
+++ b/include/TGUI/Loading/WidgetFactory.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/ObjectConverter.hpp
+++ b/include/TGUI/ObjectConverter.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Optional.hpp
+++ b/include/TGUI/Optional.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Outline.hpp
+++ b/include/TGUI/Outline.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Rect.hpp
+++ b/include/TGUI/Rect.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/RelFloatRect.hpp
+++ b/include/TGUI/RelFloatRect.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/RenderStates.hpp
+++ b/include/TGUI/RenderStates.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/RendererDefines.hpp
+++ b/include/TGUI/RendererDefines.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Renderers/BoxLayoutRenderer.hpp
+++ b/include/TGUI/Renderers/BoxLayoutRenderer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Renderers/ButtonRenderer.hpp
+++ b/include/TGUI/Renderers/ButtonRenderer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Renderers/ChatBoxRenderer.hpp
+++ b/include/TGUI/Renderers/ChatBoxRenderer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Renderers/CheckBoxRenderer.hpp
+++ b/include/TGUI/Renderers/CheckBoxRenderer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Renderers/ChildWindowRenderer.hpp
+++ b/include/TGUI/Renderers/ChildWindowRenderer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Renderers/ColorPickerRenderer.hpp
+++ b/include/TGUI/Renderers/ColorPickerRenderer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Renderers/ComboBoxRenderer.hpp
+++ b/include/TGUI/Renderers/ComboBoxRenderer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Renderers/ContextMenuRenderer.hpp
+++ b/include/TGUI/Renderers/ContextMenuRenderer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Renderers/EditBoxRenderer.hpp
+++ b/include/TGUI/Renderers/EditBoxRenderer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Renderers/FileDialogRenderer.hpp
+++ b/include/TGUI/Renderers/FileDialogRenderer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Renderers/GroupRenderer.hpp
+++ b/include/TGUI/Renderers/GroupRenderer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Renderers/KnobRenderer.hpp
+++ b/include/TGUI/Renderers/KnobRenderer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Renderers/LabelRenderer.hpp
+++ b/include/TGUI/Renderers/LabelRenderer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Renderers/ListBoxRenderer.hpp
+++ b/include/TGUI/Renderers/ListBoxRenderer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Renderers/ListViewRenderer.hpp
+++ b/include/TGUI/Renderers/ListViewRenderer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Renderers/MenuBarRenderer.hpp
+++ b/include/TGUI/Renderers/MenuBarRenderer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Renderers/MenuWidgetBaseRenderer.hpp
+++ b/include/TGUI/Renderers/MenuWidgetBaseRenderer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Renderers/MessageBoxRenderer.hpp
+++ b/include/TGUI/Renderers/MessageBoxRenderer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Renderers/PanelListBoxRenderer.hpp
+++ b/include/TGUI/Renderers/PanelListBoxRenderer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Renderers/PanelRenderer.hpp
+++ b/include/TGUI/Renderers/PanelRenderer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Renderers/PictureRenderer.hpp
+++ b/include/TGUI/Renderers/PictureRenderer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Renderers/ProgressBarRenderer.hpp
+++ b/include/TGUI/Renderers/ProgressBarRenderer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Renderers/RadioButtonRenderer.hpp
+++ b/include/TGUI/Renderers/RadioButtonRenderer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Renderers/RangeSliderRenderer.hpp
+++ b/include/TGUI/Renderers/RangeSliderRenderer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Renderers/ScrollablePanelRenderer.hpp
+++ b/include/TGUI/Renderers/ScrollablePanelRenderer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Renderers/ScrollbarRenderer.hpp
+++ b/include/TGUI/Renderers/ScrollbarRenderer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Renderers/SeparatorLineRenderer.hpp
+++ b/include/TGUI/Renderers/SeparatorLineRenderer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Renderers/SliderRenderer.hpp
+++ b/include/TGUI/Renderers/SliderRenderer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Renderers/SpinButtonRenderer.hpp
+++ b/include/TGUI/Renderers/SpinButtonRenderer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Renderers/SplitContainerRenderer.hpp
+++ b/include/TGUI/Renderers/SplitContainerRenderer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Renderers/TabsRenderer.hpp
+++ b/include/TGUI/Renderers/TabsRenderer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Renderers/TextAreaRenderer.hpp
+++ b/include/TGUI/Renderers/TextAreaRenderer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Renderers/TextBoxRenderer.hpp
+++ b/include/TGUI/Renderers/TextBoxRenderer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Renderers/TreeViewRenderer.hpp
+++ b/include/TGUI/Renderers/TreeViewRenderer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Renderers/WidgetRenderer.hpp
+++ b/include/TGUI/Renderers/WidgetRenderer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Signal.hpp
+++ b/include/TGUI/Signal.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/SignalManager.hpp
+++ b/include/TGUI/SignalManager.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Sprite.hpp
+++ b/include/TGUI/Sprite.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/String.hpp
+++ b/include/TGUI/String.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/StringView.hpp
+++ b/include/TGUI/StringView.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/SubwidgetContainer.hpp
+++ b/include/TGUI/SubwidgetContainer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/SvgImage.hpp
+++ b/include/TGUI/SvgImage.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/TGUI.hpp
+++ b/include/TGUI/TGUI.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Text.hpp
+++ b/include/TGUI/Text.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/TextStyle.hpp
+++ b/include/TGUI/TextStyle.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Texture.hpp
+++ b/include/TGUI/Texture.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/TextureData.hpp
+++ b/include/TGUI/TextureData.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/TextureManager.hpp
+++ b/include/TGUI/TextureManager.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Timer.hpp
+++ b/include/TGUI/Timer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/ToolTip.hpp
+++ b/include/TGUI/ToolTip.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Transform.hpp
+++ b/include/TGUI/Transform.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/TwoFingerScrollDetect.hpp
+++ b/include/TGUI/TwoFingerScrollDetect.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Utf.hpp
+++ b/include/TGUI/Utf.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Variant.hpp
+++ b/include/TGUI/Variant.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Vector2.hpp
+++ b/include/TGUI/Vector2.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Vertex.hpp
+++ b/include/TGUI/Vertex.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widget.hpp
+++ b/include/TGUI/Widget.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/BitmapButton.hpp
+++ b/include/TGUI/Widgets/BitmapButton.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/BoxLayout.hpp
+++ b/include/TGUI/Widgets/BoxLayout.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/BoxLayoutRatios.hpp
+++ b/include/TGUI/Widgets/BoxLayoutRatios.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/Button.hpp
+++ b/include/TGUI/Widgets/Button.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/ButtonBase.hpp
+++ b/include/TGUI/Widgets/ButtonBase.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/CanvasBase.hpp
+++ b/include/TGUI/Widgets/CanvasBase.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/ChatBox.hpp
+++ b/include/TGUI/Widgets/ChatBox.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/CheckBox.hpp
+++ b/include/TGUI/Widgets/CheckBox.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/ChildWindow.hpp
+++ b/include/TGUI/Widgets/ChildWindow.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/ClickableWidget.hpp
+++ b/include/TGUI/Widgets/ClickableWidget.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/ColorPicker.hpp
+++ b/include/TGUI/Widgets/ColorPicker.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/ComboBox.hpp
+++ b/include/TGUI/Widgets/ComboBox.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/ContextMenu.hpp
+++ b/include/TGUI/Widgets/ContextMenu.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/EditBox.hpp
+++ b/include/TGUI/Widgets/EditBox.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/FileDialog.hpp
+++ b/include/TGUI/Widgets/FileDialog.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/Grid.hpp
+++ b/include/TGUI/Widgets/Grid.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/Group.hpp
+++ b/include/TGUI/Widgets/Group.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/GrowHorizontalLayout.hpp
+++ b/include/TGUI/Widgets/GrowHorizontalLayout.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/GrowVerticalLayout.hpp
+++ b/include/TGUI/Widgets/GrowVerticalLayout.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/HorizontalLayout.hpp
+++ b/include/TGUI/Widgets/HorizontalLayout.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/HorizontalWrap.hpp
+++ b/include/TGUI/Widgets/HorizontalWrap.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus's Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/Knob.hpp
+++ b/include/TGUI/Widgets/Knob.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/Label.hpp
+++ b/include/TGUI/Widgets/Label.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/ListBox.hpp
+++ b/include/TGUI/Widgets/ListBox.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/ListView.hpp
+++ b/include/TGUI/Widgets/ListView.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/MenuBar.hpp
+++ b/include/TGUI/Widgets/MenuBar.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/MenuWidgetBase.hpp
+++ b/include/TGUI/Widgets/MenuWidgetBase.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/MessageBox.hpp
+++ b/include/TGUI/Widgets/MessageBox.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/Panel.hpp
+++ b/include/TGUI/Widgets/Panel.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/PanelListBox.hpp
+++ b/include/TGUI/Widgets/PanelListBox.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/Picture.hpp
+++ b/include/TGUI/Widgets/Picture.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/ProgressBar.hpp
+++ b/include/TGUI/Widgets/ProgressBar.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/RadioButton.hpp
+++ b/include/TGUI/Widgets/RadioButton.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/RadioButtonGroup.hpp
+++ b/include/TGUI/Widgets/RadioButtonGroup.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/RangeSlider.hpp
+++ b/include/TGUI/Widgets/RangeSlider.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/RichTextLabel.hpp
+++ b/include/TGUI/Widgets/RichTextLabel.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/ScrollablePanel.hpp
+++ b/include/TGUI/Widgets/ScrollablePanel.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/Scrollbar.hpp
+++ b/include/TGUI/Widgets/Scrollbar.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/SeparatorLine.hpp
+++ b/include/TGUI/Widgets/SeparatorLine.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/Slider.hpp
+++ b/include/TGUI/Widgets/Slider.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/SpinButton.hpp
+++ b/include/TGUI/Widgets/SpinButton.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/SpinControl.hpp
+++ b/include/TGUI/Widgets/SpinControl.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/SplitContainer.hpp
+++ b/include/TGUI/Widgets/SplitContainer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/TabContainer.hpp
+++ b/include/TGUI/Widgets/TabContainer.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/Tabs.hpp
+++ b/include/TGUI/Widgets/Tabs.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/TextArea.hpp
+++ b/include/TGUI/Widgets/TextArea.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/ToggleButton.hpp
+++ b/include/TGUI/Widgets/ToggleButton.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/TreeView.hpp
+++ b/include/TGUI/Widgets/TreeView.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/Widgets/VerticalLayout.hpp
+++ b/include/TGUI/Widgets/VerticalLayout.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/WindowsIMM.hpp
+++ b/include/TGUI/WindowsIMM.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/extlibs/IncludeNanoSVG.hpp
+++ b/include/TGUI/extlibs/IncludeNanoSVG.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/extlibs/IncludeSDL.hpp
+++ b/include/TGUI/extlibs/IncludeSDL.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/extlibs/IncludeStbImage.hpp
+++ b/include/TGUI/extlibs/IncludeStbImage.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/extlibs/IncludeStbImageWrite.hpp
+++ b/include/TGUI/extlibs/IncludeStbImageWrite.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/include/TGUI/extlibs/IncludeWindows.hpp
+++ b/include/TGUI/extlibs/IncludeWindows.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/license.txt
+++ b/license.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2012-2025 Bruno Van de Velde - vdv_b@tgui.eu
+Copyright (c) 2012-2026 Bruno Van de Velde - vdv_b@tgui.eu
 
 This software is provided 'as-is', without any express or
 implied warranty. In no event will the authors be held

--- a/src/Animation.cpp
+++ b/src/Animation.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/CMakeLists.txt
+++ b/src/Backend/CMakeLists.txt
@@ -1,6 +1,6 @@
 ####################################################################################################
 # TGUI - Texus' Graphical User Interface
-# Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+# Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 #
 # This software is provided 'as-is', without any express or implied warranty.
 # In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Font/BackendFont.cpp
+++ b/src/Backend/Font/BackendFont.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Font/FreeType/BackendFontFreeType.cpp
+++ b/src/Backend/Font/FreeType/BackendFontFreeType.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Font/FreeType/BackendFontFreeType.cppm
+++ b/src/Backend/Font/FreeType/BackendFontFreeType.cppm
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Font/Raylib/BackendFontRaylib.cpp
+++ b/src/Backend/Font/Raylib/BackendFontRaylib.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Font/Raylib/BackendFontRaylib.cppm
+++ b/src/Backend/Font/Raylib/BackendFontRaylib.cppm
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Font/SDL_ttf/BackendFontSDLttf.cpp
+++ b/src/Backend/Font/SDL_ttf/BackendFontSDLttf.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Font/SDL_ttf/BackendFontSDLttf.cppm
+++ b/src/Backend/Font/SDL_ttf/BackendFontSDLttf.cppm
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Font/SFML-Graphics/BackendFontSFML.cpp
+++ b/src/Backend/Font/SFML-Graphics/BackendFontSFML.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Font/SFML-Graphics/BackendFontSFML.cppm
+++ b/src/Backend/Font/SFML-Graphics/BackendFontSFML.cppm
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/GLFW-GLES2.cpp
+++ b/src/Backend/GLFW-GLES2.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/GLFW-GLES2.cppm
+++ b/src/Backend/GLFW-GLES2.cppm
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/GLFW-OpenGL3.cpp
+++ b/src/Backend/GLFW-OpenGL3.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/GLFW-OpenGL3.cppm
+++ b/src/Backend/GLFW-OpenGL3.cppm
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Renderer/BackendRenderTarget.cpp
+++ b/src/Backend/Renderer/BackendRenderTarget.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Renderer/BackendText.cpp
+++ b/src/Backend/Renderer/BackendText.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Renderer/BackendTexture.cpp
+++ b/src/Backend/Renderer/BackendTexture.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Renderer/GLES2/BackendRenderTargetGLES2.cpp
+++ b/src/Backend/Renderer/GLES2/BackendRenderTargetGLES2.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Renderer/GLES2/BackendRendererGLES2.cpp
+++ b/src/Backend/Renderer/GLES2/BackendRendererGLES2.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Renderer/GLES2/BackendRendererGLES2.cppm
+++ b/src/Backend/Renderer/GLES2/BackendRendererGLES2.cppm
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Renderer/GLES2/BackendTextureGLES2.cpp
+++ b/src/Backend/Renderer/GLES2/BackendTextureGLES2.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Renderer/GLES2/CanvasGLES2.cpp
+++ b/src/Backend/Renderer/GLES2/CanvasGLES2.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Renderer/OpenGL.cpp
+++ b/src/Backend/Renderer/OpenGL.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Renderer/OpenGL3/BackendRenderTargetOpenGL3.cpp
+++ b/src/Backend/Renderer/OpenGL3/BackendRenderTargetOpenGL3.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Renderer/OpenGL3/BackendRendererOpenGL3.cpp
+++ b/src/Backend/Renderer/OpenGL3/BackendRendererOpenGL3.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Renderer/OpenGL3/BackendRendererOpenGL3.cppm
+++ b/src/Backend/Renderer/OpenGL3/BackendRendererOpenGL3.cppm
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Renderer/OpenGL3/BackendTextureOpenGL3.cpp
+++ b/src/Backend/Renderer/OpenGL3/BackendTextureOpenGL3.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Renderer/OpenGL3/CanvasOpenGL3.cpp
+++ b/src/Backend/Renderer/OpenGL3/CanvasOpenGL3.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Renderer/Raylib/BackendRenderTargetRaylib.cpp
+++ b/src/Backend/Renderer/Raylib/BackendRenderTargetRaylib.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Renderer/Raylib/BackendRendererRaylib.cpp
+++ b/src/Backend/Renderer/Raylib/BackendRendererRaylib.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Renderer/Raylib/BackendRendererRaylib.cppm
+++ b/src/Backend/Renderer/Raylib/BackendRendererRaylib.cppm
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Renderer/Raylib/BackendTextureRaylib.cpp
+++ b/src/Backend/Renderer/Raylib/BackendTextureRaylib.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Renderer/Raylib/CanvasRaylib.cpp
+++ b/src/Backend/Renderer/Raylib/CanvasRaylib.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Renderer/SDL_GPU/BackendRenderTargetSDLGPU.cpp
+++ b/src/Backend/Renderer/SDL_GPU/BackendRenderTargetSDLGPU.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Renderer/SDL_GPU/BackendRendererSDLGPU.cpp
+++ b/src/Backend/Renderer/SDL_GPU/BackendRendererSDLGPU.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Renderer/SDL_GPU/BackendRendererSDLGPU.cppm
+++ b/src/Backend/Renderer/SDL_GPU/BackendRendererSDLGPU.cppm
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Renderer/SDL_GPU/BackendTextureSDLGPU.cpp
+++ b/src/Backend/Renderer/SDL_GPU/BackendTextureSDLGPU.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Renderer/SDL_GPU/CanvasSDLGPU.cpp
+++ b/src/Backend/Renderer/SDL_GPU/CanvasSDLGPU.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Renderer/SDL_Renderer/BackendRenderTargetSDL.cpp
+++ b/src/Backend/Renderer/SDL_Renderer/BackendRenderTargetSDL.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Renderer/SDL_Renderer/BackendRendererSDL.cpp
+++ b/src/Backend/Renderer/SDL_Renderer/BackendRendererSDL.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Renderer/SDL_Renderer/BackendRendererSDL.cppm
+++ b/src/Backend/Renderer/SDL_Renderer/BackendRendererSDL.cppm
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Renderer/SDL_Renderer/BackendTextureSDL.cpp
+++ b/src/Backend/Renderer/SDL_Renderer/BackendTextureSDL.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Renderer/SDL_Renderer/CanvasSDL.cpp
+++ b/src/Backend/Renderer/SDL_Renderer/CanvasSDL.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Renderer/SFML-Graphics/BackendRenderTargetSFML.cpp
+++ b/src/Backend/Renderer/SFML-Graphics/BackendRenderTargetSFML.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Renderer/SFML-Graphics/BackendRendererSFML.cpp
+++ b/src/Backend/Renderer/SFML-Graphics/BackendRendererSFML.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Renderer/SFML-Graphics/BackendRendererSFML.cppm
+++ b/src/Backend/Renderer/SFML-Graphics/BackendRendererSFML.cppm
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Renderer/SFML-Graphics/BackendTextureSFML.cpp
+++ b/src/Backend/Renderer/SFML-Graphics/BackendTextureSFML.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Renderer/SFML-Graphics/CanvasSFML.cpp
+++ b/src/Backend/Renderer/SFML-Graphics/CanvasSFML.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/SDL-GLES2.cpp
+++ b/src/Backend/SDL-GLES2.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/SDL-GLES2.cppm
+++ b/src/Backend/SDL-GLES2.cppm
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/SDL-GPU.cpp
+++ b/src/Backend/SDL-GPU.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/SDL-GPU.cppm
+++ b/src/Backend/SDL-GPU.cppm
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/SDL-OpenGL3.cpp
+++ b/src/Backend/SDL-OpenGL3.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/SDL-OpenGL3.cppm
+++ b/src/Backend/SDL-OpenGL3.cppm
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/SDL-Renderer.cpp
+++ b/src/Backend/SDL-Renderer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/SDL-Renderer.cppm
+++ b/src/Backend/SDL-Renderer.cppm
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/SDL-TTF-GLES2.cpp
+++ b/src/Backend/SDL-TTF-GLES2.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/SDL-TTF-GLES2.cppm
+++ b/src/Backend/SDL-TTF-GLES2.cppm
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/SDL-TTF-OpenGL3.cpp
+++ b/src/Backend/SDL-TTF-OpenGL3.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/SDL-TTF-OpenGL3.cppm
+++ b/src/Backend/SDL-TTF-OpenGL3.cppm
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/SFML-Graphics.cpp
+++ b/src/Backend/SFML-Graphics.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/SFML-Graphics.cppm
+++ b/src/Backend/SFML-Graphics.cppm
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/SFML-OpenGL3.cpp
+++ b/src/Backend/SFML-OpenGL3.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/SFML-OpenGL3.cppm
+++ b/src/Backend/SFML-OpenGL3.cppm
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Window/Backend.cpp
+++ b/src/Backend/Window/Backend.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Window/BackendGui.cpp
+++ b/src/Backend/Window/BackendGui.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Window/GLFW/BackendGLFW.cpp
+++ b/src/Backend/Window/GLFW/BackendGLFW.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Window/GLFW/BackendGuiGLFW.cpp
+++ b/src/Backend/Window/GLFW/BackendGuiGLFW.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Window/GLFW/BackendWindowGLFW.cppm
+++ b/src/Backend/Window/GLFW/BackendWindowGLFW.cppm
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Window/Raylib/BackendGuiRaylib.cpp
+++ b/src/Backend/Window/Raylib/BackendGuiRaylib.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Window/Raylib/BackendRaylib.cpp
+++ b/src/Backend/Window/Raylib/BackendRaylib.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Window/Raylib/BackendWindowRaylib.cppm
+++ b/src/Backend/Window/Raylib/BackendWindowRaylib.cppm
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Window/SDL/BackendGuiSDL.cpp
+++ b/src/Backend/Window/SDL/BackendGuiSDL.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Window/SDL/BackendSDL.cpp
+++ b/src/Backend/Window/SDL/BackendSDL.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Window/SDL/BackendWindowSDL.cppm
+++ b/src/Backend/Window/SDL/BackendWindowSDL.cppm
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Window/SFML/BackendGuiSFML.cpp
+++ b/src/Backend/Window/SFML/BackendGuiSFML.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Window/SFML/BackendSFML.cpp
+++ b/src/Backend/Window/SFML/BackendSFML.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/Window/SFML/BackendWindowSFML.cppm
+++ b/src/Backend/Window/SFML/BackendWindowSFML.cppm
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/raylib.cpp
+++ b/src/Backend/raylib.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Backend/raylib.cppm
+++ b/src/Backend/raylib.cppm
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Base64.cpp
+++ b/src/Base64.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 ####################################################################################################
 # TGUI - Texus' Graphical User Interface
-# Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+# Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 #
 # This software is provided 'as-is', without any express or implied warranty.
 # In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Color.cpp
+++ b/src/Color.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Components.cpp
+++ b/src/Components.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Container.cpp
+++ b/src/Container.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Cursor.cpp
+++ b/src/Cursor.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/CustomWidgetForBindings.cpp
+++ b/src/CustomWidgetForBindings.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/DefaultBackendWindow.cpp
+++ b/src/DefaultBackendWindow.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/DefaultBackendWindow.cppm
+++ b/src/DefaultBackendWindow.cppm
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/FileDialogIconLoader.cpp
+++ b/src/FileDialogIconLoader.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/FileDialogIconLoaderLinux.cpp
+++ b/src/FileDialogIconLoaderLinux.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/FileDialogIconLoaderWindows.cpp
+++ b/src/FileDialogIconLoaderWindows.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Filesystem.cpp
+++ b/src/Filesystem.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Font.cpp
+++ b/src/Font.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Global.cpp
+++ b/src/Global.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Layout.cpp
+++ b/src/Layout.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Loading/DataIO.cpp
+++ b/src/Loading/DataIO.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Loading/Deserializer.cpp
+++ b/src/Loading/Deserializer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Loading/ImageLoader.cpp
+++ b/src/Loading/ImageLoader.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Loading/Serializer.cpp
+++ b/src/Loading/Serializer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Loading/Theme.cpp
+++ b/src/Loading/Theme.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Loading/ThemeLoader.cpp
+++ b/src/Loading/ThemeLoader.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Loading/WidgetFactory.cpp
+++ b/src/Loading/WidgetFactory.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/ObjectConverter.cpp
+++ b/src/ObjectConverter.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Renderers/BoxLayoutRenderer.cpp
+++ b/src/Renderers/BoxLayoutRenderer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Renderers/ButtonRenderer.cpp
+++ b/src/Renderers/ButtonRenderer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Renderers/ChatBoxRenderer.cpp
+++ b/src/Renderers/ChatBoxRenderer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Renderers/ChildWindowRenderer.cpp
+++ b/src/Renderers/ChildWindowRenderer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Renderers/ColorPickerRenderer.cpp
+++ b/src/Renderers/ColorPickerRenderer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Renderers/ComboBoxRenderer.cpp
+++ b/src/Renderers/ComboBoxRenderer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Renderers/EditBoxRenderer.cpp
+++ b/src/Renderers/EditBoxRenderer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Renderers/FileDialogRenderer.cpp
+++ b/src/Renderers/FileDialogRenderer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Renderers/GroupRenderer.cpp
+++ b/src/Renderers/GroupRenderer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Renderers/KnobRenderer.cpp
+++ b/src/Renderers/KnobRenderer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Renderers/LabelRenderer.cpp
+++ b/src/Renderers/LabelRenderer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Renderers/ListBoxRenderer.cpp
+++ b/src/Renderers/ListBoxRenderer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Renderers/ListViewRenderer.cpp
+++ b/src/Renderers/ListViewRenderer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Renderers/MenuBarRenderer.cpp
+++ b/src/Renderers/MenuBarRenderer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Renderers/MenuWidgetBaseRenderer.cpp
+++ b/src/Renderers/MenuWidgetBaseRenderer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Renderers/MessageBoxRenderer.cpp
+++ b/src/Renderers/MessageBoxRenderer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Renderers/PanelListBoxRenderer.cpp
+++ b/src/Renderers/PanelListBoxRenderer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Renderers/PanelRenderer.cpp
+++ b/src/Renderers/PanelRenderer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Renderers/PictureRenderer.cpp
+++ b/src/Renderers/PictureRenderer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Renderers/ProgressBarRenderer.cpp
+++ b/src/Renderers/ProgressBarRenderer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Renderers/RadioButtonRenderer.cpp
+++ b/src/Renderers/RadioButtonRenderer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Renderers/RangeSliderRenderer.cpp
+++ b/src/Renderers/RangeSliderRenderer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Renderers/ScrollablePanelRenderer.cpp
+++ b/src/Renderers/ScrollablePanelRenderer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Renderers/ScrollbarRenderer.cpp
+++ b/src/Renderers/ScrollbarRenderer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Renderers/SeparatorLineRenderer.cpp
+++ b/src/Renderers/SeparatorLineRenderer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Renderers/SliderRenderer.cpp
+++ b/src/Renderers/SliderRenderer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Renderers/SpinButtonRenderer.cpp
+++ b/src/Renderers/SpinButtonRenderer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Renderers/SplitContainerRenderer.cpp
+++ b/src/Renderers/SplitContainerRenderer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Renderers/TabsRenderer.cpp
+++ b/src/Renderers/TabsRenderer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Renderers/TextAreaRenderer.cpp
+++ b/src/Renderers/TextAreaRenderer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Renderers/TreeViewRenderer.cpp
+++ b/src/Renderers/TreeViewRenderer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Renderers/WidgetRenderer.cpp
+++ b/src/Renderers/WidgetRenderer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Signal.cpp
+++ b/src/Signal.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/SignalManager.cpp
+++ b/src/SignalManager.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Sprite.cpp
+++ b/src/Sprite.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/String.cpp
+++ b/src/String.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/SubwidgetContainer.cpp
+++ b/src/SubwidgetContainer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/SvgImage.cpp
+++ b/src/SvgImage.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/TGUI.cppm
+++ b/src/TGUI.cppm
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Text.cpp
+++ b/src/Text.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/TextStyle.cpp
+++ b/src/TextStyle.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Texture.cpp
+++ b/src/Texture.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/TextureManager.cpp
+++ b/src/TextureManager.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Timer.cpp
+++ b/src/Timer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/ToolTip.cpp
+++ b/src/ToolTip.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Transform.cpp
+++ b/src/Transform.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/TwoFingerScrollDetect.cpp
+++ b/src/TwoFingerScrollDetect.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widget.cpp
+++ b/src/Widget.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/BitmapButton.cpp
+++ b/src/Widgets/BitmapButton.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/BoxLayout.cpp
+++ b/src/Widgets/BoxLayout.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/BoxLayoutRatios.cpp
+++ b/src/Widgets/BoxLayoutRatios.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/Button.cpp
+++ b/src/Widgets/Button.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/ButtonBase.cpp
+++ b/src/Widgets/ButtonBase.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/CanvasBase.cpp
+++ b/src/Widgets/CanvasBase.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/ChatBox.cpp
+++ b/src/Widgets/ChatBox.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/CheckBox.cpp
+++ b/src/Widgets/CheckBox.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/ChildWindow.cpp
+++ b/src/Widgets/ChildWindow.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/ClickableWidget.cpp
+++ b/src/Widgets/ClickableWidget.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/ColorPicker.cpp
+++ b/src/Widgets/ColorPicker.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/ComboBox.cpp
+++ b/src/Widgets/ComboBox.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/ContextMenu.cpp
+++ b/src/Widgets/ContextMenu.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/EditBox.cpp
+++ b/src/Widgets/EditBox.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/FileDialog.cpp
+++ b/src/Widgets/FileDialog.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/Grid.cpp
+++ b/src/Widgets/Grid.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/Group.cpp
+++ b/src/Widgets/Group.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/GrowHorizontalLayout.cpp
+++ b/src/Widgets/GrowHorizontalLayout.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/GrowVerticalLayout.cpp
+++ b/src/Widgets/GrowVerticalLayout.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/HorizontalLayout.cpp
+++ b/src/Widgets/HorizontalLayout.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/HorizontalWrap.cpp
+++ b/src/Widgets/HorizontalWrap.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/Knob.cpp
+++ b/src/Widgets/Knob.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/Label.cpp
+++ b/src/Widgets/Label.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/ListBox.cpp
+++ b/src/Widgets/ListBox.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/ListView.cpp
+++ b/src/Widgets/ListView.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/MenuBar.cpp
+++ b/src/Widgets/MenuBar.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/MenuWidgetBase.cpp
+++ b/src/Widgets/MenuWidgetBase.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/MessageBox.cpp
+++ b/src/Widgets/MessageBox.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/Panel.cpp
+++ b/src/Widgets/Panel.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/PanelListBox.cpp
+++ b/src/Widgets/PanelListBox.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/Picture.cpp
+++ b/src/Widgets/Picture.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/ProgressBar.cpp
+++ b/src/Widgets/ProgressBar.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/RadioButton.cpp
+++ b/src/Widgets/RadioButton.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/RadioButtonGroup.cpp
+++ b/src/Widgets/RadioButtonGroup.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/RangeSlider.cpp
+++ b/src/Widgets/RangeSlider.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/RichTextLabel.cpp
+++ b/src/Widgets/RichTextLabel.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/ScrollablePanel.cpp
+++ b/src/Widgets/ScrollablePanel.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/Scrollbar.cpp
+++ b/src/Widgets/Scrollbar.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/SeparatorLine.cpp
+++ b/src/Widgets/SeparatorLine.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/Slider.cpp
+++ b/src/Widgets/Slider.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/SpinButton.cpp
+++ b/src/Widgets/SpinButton.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/SpinControl.cpp
+++ b/src/Widgets/SpinControl.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/SplitContainer.cpp
+++ b/src/Widgets/SplitContainer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/TabContainer.cpp
+++ b/src/Widgets/TabContainer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/Tabs.cpp
+++ b/src/Widgets/Tabs.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/TextArea.cpp
+++ b/src/Widgets/TextArea.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/ToggleButton.cpp
+++ b/src/Widgets/ToggleButton.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/TreeView.cpp
+++ b/src/Widgets/TreeView.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/Widgets/VerticalLayout.cpp
+++ b/src/Widgets/VerticalLayout.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/src/WindowsIMM.cpp
+++ b/src/WindowsIMM.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/AbsoluteOrRelativeValue.cpp
+++ b/tests/AbsoluteOrRelativeValue.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Animation.cpp
+++ b/tests/Animation.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/BackendEvents.cpp
+++ b/tests/BackendEvents.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 ####################################################################################################
 # TGUI - Texus' Graphical User Interface
-# Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+# Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 #
 # This software is provided 'as-is', without any express or implied warranty.
 # In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Clipboard.cpp
+++ b/tests/Clipboard.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Clipping.cpp
+++ b/tests/Clipping.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Color.cpp
+++ b/tests/Color.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/CompareFiles.cpp
+++ b/tests/CompareFiles.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Container.cpp
+++ b/tests/Container.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Duration.cpp
+++ b/tests/Duration.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Filesystem.cpp
+++ b/tests/Filesystem.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Focus.cpp
+++ b/tests/Focus.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Font.cpp
+++ b/tests/Font.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Layouts.cpp
+++ b/tests/Layouts.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Loading/DataIO.cpp
+++ b/tests/Loading/DataIO.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Loading/Deserializer.cpp
+++ b/tests/Loading/Deserializer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Loading/Serializer.cpp
+++ b/tests/Loading/Serializer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Loading/Theme.cpp
+++ b/tests/Loading/Theme.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Loading/ThemeLoader.cpp
+++ b/tests/Loading/ThemeLoader.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/MouseCursors.cpp
+++ b/tests/MouseCursors.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Outline.cpp
+++ b/tests/Outline.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Signal.cpp
+++ b/tests/Signal.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/SignalManager.cpp
+++ b/tests/SignalManager.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Sprite.cpp
+++ b/tests/Sprite.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/String.cpp
+++ b/tests/String.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/SvgImage.cpp
+++ b/tests/SvgImage.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Tests.cpp
+++ b/tests/Tests.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Tests.hpp
+++ b/tests/Tests.hpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Text.cpp
+++ b/tests/Text.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Texture.cpp
+++ b/tests/Texture.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/TextureManager.cpp
+++ b/tests/TextureManager.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Timer.cpp
+++ b/tests/Timer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/ToolTip.cpp
+++ b/tests/ToolTip.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Vector2.cpp
+++ b/tests/Vector2.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widget.cpp
+++ b/tests/Widget.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/BitmapButton.cpp
+++ b/tests/Widgets/BitmapButton.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/Button.cpp
+++ b/tests/Widgets/Button.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/Canvas.cpp
+++ b/tests/Widgets/Canvas.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/ChatBox.cpp
+++ b/tests/Widgets/ChatBox.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/CheckBox.cpp
+++ b/tests/Widgets/CheckBox.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/ChildWindow.cpp
+++ b/tests/Widgets/ChildWindow.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/ClickableWidget.cpp
+++ b/tests/Widgets/ClickableWidget.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/ColorPicker.cpp
+++ b/tests/Widgets/ColorPicker.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/ComboBox.cpp
+++ b/tests/Widgets/ComboBox.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/ContextMenu.cpp
+++ b/tests/Widgets/ContextMenu.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/EditBox.cpp
+++ b/tests/Widgets/EditBox.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/EditBoxSlider.cpp
+++ b/tests/Widgets/EditBoxSlider.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/FileDialog.cpp
+++ b/tests/Widgets/FileDialog.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/Grid.cpp
+++ b/tests/Widgets/Grid.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/Group.cpp
+++ b/tests/Widgets/Group.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/GrowHorizontalLayout.cpp
+++ b/tests/Widgets/GrowHorizontalLayout.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/GrowVerticalLayout.cpp
+++ b/tests/Widgets/GrowVerticalLayout.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/HorizontalLayout.cpp
+++ b/tests/Widgets/HorizontalLayout.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/HorizontalWrap.cpp
+++ b/tests/Widgets/HorizontalWrap.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/Knob.cpp
+++ b/tests/Widgets/Knob.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/Label.cpp
+++ b/tests/Widgets/Label.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/ListBox.cpp
+++ b/tests/Widgets/ListBox.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/ListView.cpp
+++ b/tests/Widgets/ListView.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/MenuBar.cpp
+++ b/tests/Widgets/MenuBar.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/MessageBox.cpp
+++ b/tests/Widgets/MessageBox.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/Panel.cpp
+++ b/tests/Widgets/Panel.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/PanelListBox.cpp
+++ b/tests/Widgets/PanelListBox.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/Picture.cpp
+++ b/tests/Widgets/Picture.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/ProgressBar.cpp
+++ b/tests/Widgets/ProgressBar.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/RadioButton.cpp
+++ b/tests/Widgets/RadioButton.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/RadioButtonGroup.cpp
+++ b/tests/Widgets/RadioButtonGroup.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/RangeSlider.cpp
+++ b/tests/Widgets/RangeSlider.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/RichTextLabel.cpp
+++ b/tests/Widgets/RichTextLabel.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/ScrollablePanel.cpp
+++ b/tests/Widgets/ScrollablePanel.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/Scrollbar.cpp
+++ b/tests/Widgets/Scrollbar.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/SeparatorLine.cpp
+++ b/tests/Widgets/SeparatorLine.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/Slider.cpp
+++ b/tests/Widgets/Slider.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/SpinButton.cpp
+++ b/tests/Widgets/SpinButton.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/SpinControl.cpp
+++ b/tests/Widgets/SpinControl.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/SplitContainer.cpp
+++ b/tests/Widgets/SplitContainer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/TabContainer.cpp
+++ b/tests/Widgets/TabContainer.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/Tabs.cpp
+++ b/tests/Widgets/Tabs.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/TextArea.cpp
+++ b/tests/Widgets/TextArea.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/ToggleButton.cpp
+++ b/tests/Widgets/ToggleButton.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/TreeView.cpp
+++ b/tests/Widgets/TreeView.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/Widgets/VerticalLayout.cpp
+++ b/tests/Widgets/VerticalLayout.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // TGUI - Texus' Graphical User Interface
-// Copyright (C) 2012-2025 Bruno Van de Velde (vdv_b@tgui.eu)
+// Copyright (C) 2012-2026 Bruno Van de Velde (vdv_b@tgui.eu)
 //
 // This software is provided 'as-is', without any express or implied warranty.
 // In no event will the authors be held liable for any damages arising from the use of this software.


### PR DESCRIPTION
It's now 2026, so the year in the copyright statement in various files should be updated from 2025 to 2026.