### PR TITLE
Return EXIT_SUCCESS/EXIT_FAILURE from main()

### DIFF
--- a/gui-builder/src/main.cpp
+++ b/gui-builder/src/main.cpp
@@ -23,6 +23,7 @@
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #include <TGUI/Config.hpp>
+#include <cstdlib>
 #ifdef TGUI_SYSTEM_WINDOWS
     #include <TGUI/extlibs/IncludeWindows.hpp> // GetCommandLineW
     #include <shellapi.h> // CommandLineToArgvW
@@ -78,17 +79,17 @@ int main(int, char* argv[])
     catch (const tgui::Exception& e)
     {
         std::cerr << "TGUI exception thrown: " << e.what() << '\n';
-        return 1;
+        return EXIT_FAILURE;
     }
     catch (const std::exception& e)
     {
         std::cerr << "Exception thrown: " << e.what() << '\n';
-        return 1;
+        return EXIT_FAILURE;
     }
     catch (...)
     {
         std::cerr << "Unknown exception thrown\n";
-        return 1;
+        return EXIT_FAILURE;
     }
-    return 0;
+    return EXIT_SUCCESS;
 }

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -530,7 +530,7 @@ int main(int argc, char * argv[])
 
     session.cli(cli);
     if (session.applyCommandLine(argc, argv) != 0)
-      return 1;
+      return EXIT_FAILURE;
 
     std::unique_ptr<TestsWindowBase> window;
     if (selectedBackend.empty())
@@ -585,7 +585,7 @@ int main(int argc, char * argv[])
         if (!window)
         {
             std::cerr << "Backend parameter was provided but no matching backend was enabled TGUI\n";
-            return 1;
+            return EXIT_FAILURE;
         }
     }
 


### PR DESCRIPTION
The macros exist for a reason; not all systems use the same integer values to signal success or failure.  Although all systems that TGUI currently supports use a 0 return from main to indicate success and everything else as failure, that's not universal. For example, VMS uses 1 to indicate success.

In the future TGUI may be ported to systems where the EXIT_SUCCESS/EXIT_FAILURE macros are relevant, so that's one reason to use them and also; they are just a lot more expressive/readable and make perfectly clear what's being returned, so that's another reason to use them.