### PR TITLE
Remove erroneously added include

### DIFF
--- a/tests/Widgets/FileDialog.cpp
+++ b/tests/Widgets/FileDialog.cpp
@@ -28,8 +28,6 @@
 
 #include <TGUI/FileDialogIconLoader.hpp>
 
-#include <SFML/Graphics/Texture.hpp>
-
 TEST_CASE("[FileDialog]")
 {
     const tgui::FileDialog::Ptr dialog = tgui::FileDialog::create();


### PR DESCRIPTION
Commit 66185b8353f46b9363a6fb8194b741ff0a7461a6 accidentally added the inclusion of a header it shouldn't have.