### PR TITLE
Enable /Zc:throwingNew when building with MSVC

### DIFF
--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -54,6 +54,7 @@ function(tgui_set_global_compile_flags target)
                                /Zc:__cplusplus
                                /Zc:preprocessor
                                /Zc:inline
+                               /Zc:throwingNew
                                /volatile:iso
         )
     else()


### PR DESCRIPTION
From Microsoft's documentation
(https://learn.microsoft.com/en-us/cpp/build/reference/zc-throwingnew-assume-operator-new-throws?view=msvc-170) :

"When the /Zc:throwingNew option is specified, the compiler optimizes calls to operator new to skip checks for a null pointer return. This option tells the compiler to assume that all linked implementations of operator new and custom allocators conform to the C++ standard and throw on allocation failure. By default in Visual Studio, the compiler pessimistically generates null checks (/Zc:throwingNew-) for these calls, because users can link with a non-throwing implementation of operator new or write custom allocator routines that return null pointers."

Nothing in TGUI assumes that `new` returns nullptr on failure and if any users write an allocator that does so or explicitly link to a non-conforming, non-throwing allocator, then they are advanced enough to know to locally disable this option. We should not penalize the common user to cater to an obscure corner case (and this also better matches behaviour with other compilers). Let's default to the standard compliant, and better performing, behaviour.