### PR TITLE
Raise max CMake version to 4.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@
 
 # If the cmake version is higher than the minimum version then enable all new policies, up to the maximum version specified.
 # When cmake is newer than the highest version then its newest policies will still be set to the old behavior for compatibility.
-cmake_minimum_required(VERSION 3.16...4.3)
+cmake_minimum_required(VERSION 3.16...4.4)
 
 # Include macros such as tgui_set_option
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Macros.cmake)


### PR DESCRIPTION
There's nothing in the release notes that would indicate a problem for TGUI and everything builds fine on my system with CMake 4.4, so raise the max version.