### PR TITLE
Fix size_t underflow in TabsBase::remove bounds check

### DIFF
--- a/src/Widgets/TabsBase.cpp
+++ b/src/Widgets/TabsBase.cpp
@@ -259,7 +259,7 @@ namespace tgui
     bool TabsBase::remove(std::size_t index)
     {
         // The index can't be too high
-        if (index > m_tabs.size() - 1)
+        if (index >= m_tabs.size())
             return false;
 
         // Remove the tab


### PR DESCRIPTION
## Problem

\`TabsBase::remove(std::size_t index)\` checks bounds like this:

\`\`\`cpp
if (index > m_tabs.size() - 1)
    return false;
\`\`\`

When \`m_tabs\` is empty, \`m_tabs.size() - 1\` underflows (unsigned) to \`SIZE_MAX\`, so the check never returns \`false\` and execution falls through to:

\`\`\`cpp
m_tabs.erase(m_tabs.cbegin() + static_cast<std::ptrdiff_t>(index));
\`\`\`

which erases from an empty vector at an out-of-range position, invoking undefined behavior (crashes both in a plain optimized build and under \`_GLIBCXX_DEBUG\`).

Both \`Tabs\` and \`VerticalTabs\` inherit \`remove()\` from \`TabsBase\` without overriding it, and the header doc comment for this function promises "false is returned when the index was too high" — a promise this code breaks precisely in the empty-container case.

## Fix

Rewrite the bounds check as \`index >= m_tabs.size()\`, which is safe for the empty case and matches the equivalent checks already used elsewhere in the codebase (e.g. \`BoxLayout::remove\`, \`ListBox::removeItemByIndex\`, \`TabContainer::removeTab\`).

## Testing

Extracted the exact erase/bounds logic into a standalone reproduction: calling \`remove(0)\` on an empty container segfaults with the old \`> size() - 1\` check (both under \`-O2\` and under \`_GLIBCXX_DEBUG\`), and correctly returns \`false\` with no crash after applying this fix.