### PR TITLE
Avoid UB in Text::findBestTextSize if std::lower_bound returns cbegin()

### DIFF
--- a/src/Text.cpp
+++ b/src/Text.cpp
@@ -327,8 +327,10 @@ namespace tgui
                                            height,
                                            [&](unsigned int charSize, float h)
                                            { return std::max(font.getLineSpacing(charSize), font.getFontHeight(charSize)) < h; });
-        if (high == textSizes.end())
+        if (high == textSizes.cend())
             return static_cast<unsigned int>(height);
+        if (high == textSizes.cbegin())
+            return *high;
 
         const float highLineSpacing = font.getLineSpacing(*high);
         if (highLineSpacing == height)


### PR DESCRIPTION
If std::lower_bound returns the first element then we'll run into UB when we later do
  const auto low = high - 1;
avoid that by returning *high in that case.