### PR TITLE
Cosmetic change in the Scrollbar code

### DIFF
--- a/src/Widgets/Scrollbar.cpp
+++ b/src/Widgets/Scrollbar.cpp
@@ -449,11 +449,6 @@ namespace tgui
             if (!m_mouseHover)
                 mouseEnteredWidget();
         }
-        else
-        {
-            if (m_mouseHover)
-                mouseLeftWidget();
-        }
 
         pos -= getPosition();
 
@@ -1147,7 +1142,7 @@ namespace tgui
         states.transform.translate(m_thumb.getPosition());
         if (m_spriteThumb.isSet())
         {
-            if (m_mouseHover && m_spriteThumbHover.isSet() && (m_mouseHoverOverPart == Scrollbar::Part::Thumb))
+            if (m_mouseHover && m_spriteThumbHover.isSet() && (m_mouseHoverOverPart == Scrollbar::Part::Thumb || m_mouseHoverOverPart == Scrollbar::Part::None))
                 target.drawSprite(states, m_spriteThumbHover);
             else
                 target.drawSprite(states, m_spriteThumb);

--- a/src/Widgets/Scrollbar.cpp
+++ b/src/Widgets/Scrollbar.cpp
@@ -449,6 +449,11 @@ namespace tgui
             if (!m_mouseHover)
                 mouseEnteredWidget();
         }
+        else
+        {
+            if (m_mouseHover)
+                mouseLeftWidget();
+        }
 
         pos -= getPosition();
 
@@ -1142,14 +1147,14 @@ namespace tgui
         states.transform.translate(m_thumb.getPosition());
         if (m_spriteThumb.isSet())
         {
-            if (m_mouseHover && m_spriteThumbHover.isSet() && (m_mouseHoverOverPart == Scrollbar::Part::Thumb || m_mouseHoverOverPart == Scrollbar::Part::None))
+            if (((m_mouseHover && (m_mouseHoverOverPart == Scrollbar::Part::Thumb)) || (m_mouseDown && m_mouseDownOnThumb)) && m_spriteThumbHover.isSet())
                 target.drawSprite(states, m_spriteThumbHover);
             else
                 target.drawSprite(states, m_spriteThumb);
         }
         else
         {
-            if (m_mouseHover && (m_mouseHoverOverPart == Scrollbar::Part::Thumb || m_mouseHoverOverPart == Scrollbar::Part::None) && m_thumbColorHoverCached.isSet())
+            if (((m_mouseHover && (m_mouseHoverOverPart == Scrollbar::Part::Thumb)) || (m_mouseDown && m_mouseDownOnThumb)) && m_thumbColorHoverCached.isSet())
                 target.drawFilledRect(states,
                                       {m_thumb.width, m_thumb.height},
                                       Color::applyOpacity(m_thumbColorHoverCached, m_opacityCached));

--- a/src/Widgets/Scrollbar.cpp
+++ b/src/Widgets/Scrollbar.cpp
@@ -1149,7 +1149,7 @@ namespace tgui
         }
         else
         {
-            if (m_mouseHover && (m_mouseHoverOverPart == Scrollbar::Part::Thumb) && m_thumbColorHoverCached.isSet())
+            if (m_mouseHover && (m_mouseHoverOverPart == Scrollbar::Part::Thumb || m_mouseHoverOverPart == Scrollbar::Part::None) && m_thumbColorHoverCached.isSet())
                 target.drawFilledRect(states,
                                       {m_thumb.width, m_thumb.height},
                                       Color::applyOpacity(m_thumbColorHoverCached, m_opacityCached));


### PR DESCRIPTION
I believe the Scrollbar would look a bit better if it were drawn as hovered, even if the mouse is outside it, as it is with the Slider now, so I made a small change to Scrollbar.cpp. The code is not identical to that of Slider: changes affect only the Scrollbar::draw(...) method. It seems like these changes don't break anything (I have checked the behavior of an example program manually). I hope it can be useful.