### PR TITLE
Avoid an unneeded copy in TreeView::changeItemHierarchy

### DIFF
--- a/src/Widgets/TreeView.cpp
+++ b/src/Widgets/TreeView.cpp
@@ -657,7 +657,7 @@ namespace tgui
                                oldParentNodes.cend(),
                                [node](const std::shared_ptr<Node>& child) { return child.get() == node; });
         assert(it != oldParentNodes.end());
-        auto nodeSharedPtr = *it;
+        const auto& nodeSharedPtr = *it;
         oldParentNodes.erase(it);
 
         // Add the node to the new parent


### PR DESCRIPTION
We don't need to copy-construct 'nodeSharedPtr', a const reference is fine for what we do with it, so just hold onto a const& instead of creating a copy.